### PR TITLE
Handle issues with getting the default account when unlocking Metamask on application startup.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5,9 +5,8 @@
   "requires": true,
   "dependencies": {
     "@daostack/arc.js": {
-      "version": "0.0.0-alpha.37",
-      "resolved": "https://registry.npmjs.org/@daostack/arc.js/-/arc.js-0.0.0-alpha.37.tgz",
-      "integrity": "sha512-zXF8hDwQ+sXlBHo0/V1OCmpNURTiQOD/POvn6eA1HH15dVGqmn0aWW3+zoaaxTHG+VAHGN38cVLSzS/fv1Nlyw==",
+      "version": "file:../daostack-arc.js-0.0.0-alpha.37.tgz",
+      "integrity": "sha512-ygqhehsuR/24trvmuxtJgm9RBzQvjFyMFk5T8QBzRJL0aoHqMubQC1SKKAgX7DzDQvpUAczSkB6ZzqGBy6J78g==",
       "requires": {
         "archiver": "2.1.1",
         "bignumber.js": "5.0.0",
@@ -17,6 +16,7 @@
         "decompress": "4.2.0",
         "default-options": "1.0.0",
         "env-variable": "0.0.3",
+        "es6-promisify": "6.0.0",
         "ethereumjs-abi": "0.6.5",
         "fs-extra": "5.0.0",
         "ganache-cli": "6.1.0",
@@ -27,11 +27,17 @@
         "nps-utils": "1.5.0",
         "path.join": "1.0.0",
         "pm2": "1.1.3",
-        "promisify": "0.0.3",
         "pug": "2.0.1",
         "truffle-contract": "3.0.4",
         "truffle-core-migrate-without-compile": "4.0.7",
         "uint32": "0.2.1"
+      },
+      "dependencies": {
+        "es6-promisify": {
+          "version": "6.0.0",
+          "resolved": "https://registry.npmjs.org/es6-promisify/-/es6-promisify-6.0.0.tgz",
+          "integrity": "sha512-8Tbqjrb8lC85dd81haajYwuRmiU2rkqNAFnlvQOJeeKqdUloIlI+JcUqeJruV4rCm5Y7oNU7jfs2FbmxhRR/2g=="
+        }
       }
     },
     "@sindresorhus/is": {
@@ -6861,6 +6867,10 @@
       "integrity": "sha512-YGG3ejvBNHRqu0559EOxxNFihD0AjpvHlC/pdGKd3X3ofe+CoJkYazwNJYTNebqpPKN+VVQbh4ZFn1DivMNuHA==",
       "dev": true
     },
+    "ikt": {
+      "version": "git+http://ikt.pm2.io/ikt.git#3325a3e39a502418dc2e2e4bf21529cbbde96228",
+      "optional": true
+    },
     "immutability-helper": {
       "version": "2.6.4",
       "resolved": "https://registry.npmjs.org/immutability-helper/-/immutability-helper-2.6.4.tgz",
@@ -9996,10 +10006,6 @@
             "ms": "0.7.1"
           }
         },
-        "ikt": {
-          "version": "git+http://ikt.pm2.io/ikt.git#3325a3e39a502418dc2e2e4bf21529cbbde96228",
-          "optional": true
-        },
         "ms": {
           "version": "0.7.1",
           "resolved": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz",
@@ -10663,21 +10669,6 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/promise-inflight/-/promise-inflight-1.0.1.tgz",
       "integrity": "sha1-mEcocL8igTL8vdhoEputEsPAKeM="
-    },
-    "promisify": {
-      "version": "0.0.3",
-      "resolved": "https://registry.npmjs.org/promisify/-/promisify-0.0.3.tgz",
-      "integrity": "sha1-dU22HynuZHarVDxFtGTSH171VoY=",
-      "requires": {
-        "when": "3.7.8"
-      },
-      "dependencies": {
-        "when": {
-          "version": "3.7.8",
-          "resolved": "https://registry.npmjs.org/when/-/when-3.7.8.tgz",
-          "integrity": "sha1-xxMLan6gRpPoQs3J56Hyqjmjn4I="
-        }
-      }
     },
     "promisify-node": {
       "version": "0.4.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -5,8 +5,9 @@
   "requires": true,
   "dependencies": {
     "@daostack/arc.js": {
-      "version": "file:../daostack-arc.js-0.0.0-alpha.37.tgz",
-      "integrity": "sha512-ygqhehsuR/24trvmuxtJgm9RBzQvjFyMFk5T8QBzRJL0aoHqMubQC1SKKAgX7DzDQvpUAczSkB6ZzqGBy6J78g==",
+      "version": "0.0.0-alpha.38",
+      "resolved": "https://registry.npmjs.org/@daostack/arc.js/-/arc.js-0.0.0-alpha.38.tgz",
+      "integrity": "sha512-CGnxZgRSkxa/9yAVNXcf+OmtG6cXvRih4f8YSbq19S1cUP2LBo68m32bNx1/Sc1HRAAF+HdtK8Jlm+N79aHbdw==",
       "requires": {
         "archiver": "2.1.1",
         "bignumber.js": "5.0.0",
@@ -23,7 +24,7 @@
         "has-flag": "3.0.0",
         "locate-path": "2.0.0",
         "node-glob": "1.2.0",
-        "nps": "5.8.1",
+        "nps": "5.8.2",
         "nps-utils": "1.5.0",
         "path.join": "1.0.0",
         "pm2": "1.1.3",
@@ -9186,9 +9187,9 @@
       }
     },
     "nps": {
-      "version": "5.8.1",
-      "resolved": "https://registry.npmjs.org/nps/-/nps-5.8.1.tgz",
-      "integrity": "sha512-IV/pmJdLoH1CQXZeC848YFS3lWkqmD3lPRy7smyYLM8gUQ+qDOpLRK0pNwFnmvR2MFfB3j8IqyRPaYZaR987HA==",
+      "version": "5.8.2",
+      "resolved": "https://registry.npmjs.org/nps/-/nps-5.8.2.tgz",
+      "integrity": "sha512-/OXhy44Fq+8maoLxdo804PAiZom0Cy8Wwvb8uSvq06ytF0Yq+WAcCwiMnJiNr5DaRmILtej3RVYMl7C991jAvw==",
       "requires": {
         "arrify": "1.0.1",
         "chalk": "2.3.2",
@@ -13384,7 +13385,7 @@
       "requires": {
         "fs-extra": "3.0.1",
         "github-download": "0.5.0",
-        "request": "2.83.0",
+        "request": "2.85.0",
         "tmp": "0.0.31",
         "vcsurl": "0.1.1"
       },
@@ -13515,9 +13516,9 @@
           "integrity": "sha512-eRzhrN1WSINYCDCbrz796z37LOe3m5tmW7RQf6oBntukAG1nmovJvhnwHHRMAfeoItc1m2Hk02WER2aQ/iqs+A=="
         },
         "request": {
-          "version": "2.83.0",
-          "resolved": "https://registry.npmjs.org/request/-/request-2.83.0.tgz",
-          "integrity": "sha512-lR3gD69osqm6EYLk9wB/G1W/laGWjzH90t1vEa2xuxHD5KUrSzp9pUSfTm+YC5Nxt2T8nMPEvKlhbQayU7bgFw==",
+          "version": "2.85.0",
+          "resolved": "https://registry.npmjs.org/request/-/request-2.85.0.tgz",
+          "integrity": "sha512-8H7Ehijd4js+s6wuVPLjwORxD4zeuyjYugprdOXlPSqaApmL/QOy+EB/beICHVCHkGMKNh5rvihb5ov+IDw4mg==",
           "requires": {
             "aws-sign2": "0.7.0",
             "aws4": "1.6.0",

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "auto-start-ganache": "cross-env network=ganache run-with-ganache --ganache-cmd ganache-cli \"npm run migrate-ganache && npm run start-ganache\""
   },
   "dependencies": {
-    "@daostack/arc.js": "file:../daostack-arc.js-0.0.0-alpha.37.tgz",
+    "@daostack/arc.js": "0.0.0-alpha.38",
     "axios": "^0.17.1",
     "bignumber.js": "^5.0.0",
     "classnames": "^2.2.5",

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "auto-start-ganache": "cross-env network=ganache run-with-ganache --ganache-cmd ganache-cli \"npm run migrate-ganache && npm run start-ganache\""
   },
   "dependencies": {
-    "@daostack/arc.js": "0.0.0-alpha.37",
+    "@daostack/arc.js": "file:../daostack-arc.js-0.0.0-alpha.37.tgz",
     "axios": "^0.17.1",
     "bignumber.js": "^5.0.0",
     "classnames": "^2.2.5",

--- a/src/actions/arcActions.ts
+++ b/src/actions/arcActions.ts
@@ -677,7 +677,7 @@ export function stakeProposal(daoAvatarAddress: string, proposalId: string, pred
       const votingMachineParam = await votingMachineInstance.contract.parameters(votingMachineParamHash);
       const minimumStakingFee = votingMachineParam[6]; // 6 is the index of minimumStakingFee in the Parameters struct.
 
-      const StandardToken = await Arc.Utils.requireContractAsync('StandardToken');
+      const StandardToken = await Arc.Utils.requireContract('StandardToken');
       const stakingToken = await StandardToken.at(await votingMachineInstance.contract.stakingToken());
       const balance = await stakingToken.balanceOf(currentAccountAddress);
 

--- a/src/actions/arcActions.ts
+++ b/src/actions/arcActions.ts
@@ -31,7 +31,7 @@ export function getDAOs() {
     const daoCreator = await Arc.DaoCreator.deployed();
 
     // Get the list of daos we populated on the blockchain during genesis by looking for NewOrg events
-    const newOrgEvents = daoCreator.contract.NewOrg({}, { fromBlock: 0 })
+    const newOrgEvents = daoCreator.InitialSchemesSet({}, { fromBlock: 0 })
     newOrgEvents.get(async (err : Error, eventsArray : any[]) => {
       if (err) {
         dispatch({ type: arcConstants.ARC_GET_DAOS_REJECTED, payload: "Error getting new daos from genesis contract: " + err.message });
@@ -677,7 +677,7 @@ export function stakeProposal(daoAvatarAddress: string, proposalId: string, pred
       const votingMachineParam = await votingMachineInstance.contract.parameters(votingMachineParamHash);
       const minimumStakingFee = votingMachineParam[6]; // 6 is the index of minimumStakingFee in the Parameters struct.
 
-      const StandardToken = Arc.Utils.requireContract('StandardToken');
+      const StandardToken = await Arc.Utils.requireContractAsync('StandardToken');
       const stakingToken = await StandardToken.at(await votingMachineInstance.contract.stakingToken());
       const balance = await stakingToken.balanceOf(currentAccountAddress);
 

--- a/src/actions/web3Actions.ts
+++ b/src/actions/web3Actions.ts
@@ -37,29 +37,31 @@ export function initializeWeb3() {
       ethAccountBalance: ""
     };
 
-    const getAccounts = promisify(web3.eth.getAccounts);
-    const accounts = await getAccounts();
-
-    if (accounts.length > 0) {
-      payload.ethAccountAddress = accounts[0];
-    }
-
     // TODO: actually check if we are connected to right chain
+    // TODO: is this presently needed?
     const getNetwork = promisify(web3.version.getNetwork);
-    const network = await getNetwork();
+    // await the network 
+    await getNetwork();
+    
+    try {
+      // this throws an exception if default account isn't found
+      payload.ethAccountAddress = await Utils.getDefaultAccountAsync();
 
-    if (payload.ethAccountAddress !== null) {
-      const getBalance = promisify(web3.eth.getBalance);
-      const balance = await getBalance(payload.ethAccountAddress);
-      payload.ethAccountBalance = Util.fromWei(balance).toFixed(2);
-    }
+      if (payload.ethAccountAddress !== null) {
+        const getBalance = promisify(web3.eth.getBalance);
+        const balance = await getBalance(payload.ethAccountAddress);
+        payload.ethAccountBalance = Util.fromWei(balance).toFixed(2);
+      }
+    } catch { }
+
 
     const action = {
       type: ActionTypes.WEB3_CONNECTED,
       payload: payload
     };
+
     dispatch(action);
-  };
+  }
 }
 
 export const changeAccount = (accountAddress : string) => (dispatch: Redux.Dispatch<any>, getState: Function) => {

--- a/src/actions/web3Actions.ts
+++ b/src/actions/web3Actions.ts
@@ -32,28 +32,24 @@ export function initializeWeb3() {
       return
     }
 
-    let payload : IWeb3State = {
-      ethAccountAddress: null,
-      ethAccountBalance: ""
-    };
-
     // TODO: actually check if we are connected to right chain
     // TODO: is this presently needed?
     const getNetwork = promisify(web3.version.getNetwork);
     // await the network 
     await getNetwork();
-    
+
+    let payload : IWeb3State = {
+      ethAccountAddress: null,
+      ethAccountBalance: ""
+    };
+
     try {
       // this throws an exception if default account isn't found
-      payload.ethAccountAddress = await Utils.getDefaultAccountAsync();
-
-      if (payload.ethAccountAddress !== null) {
-        const getBalance = promisify(web3.eth.getBalance);
-        const balance = await getBalance(payload.ethAccountAddress);
-        payload.ethAccountBalance = Util.fromWei(balance).toFixed(2);
-      }
+      payload.ethAccountAddress = await Utils.getDefaultAccount();
+      const getBalance = promisify(web3.eth.getBalance);
+      const balance = await getBalance(payload.ethAccountAddress);
+      payload.ethAccountBalance = Util.fromWei(balance).toFixed(2);
     } catch { }
-
 
     const action = {
       type: ActionTypes.WEB3_CONNECTED,

--- a/src/reducers/web3Reducer.ts
+++ b/src/reducers/web3Reducer.ts
@@ -28,12 +28,6 @@ const web3Reducer = (state = initialState, action: any) => {
     }
 
     case ActionTypes.WEB3_CONNECTED: {
-      // XXX: hack, for now refresh the page if we go from failing to connect to web3 to a successful connection (e.g. MetaMask unlocked)
-      //      Ideally we should be able to just force reload web3 in arc.js and get all the nice data from it, like accounts.
-      if (state.connectionStatus == ConnectionStatus.Failed) {
-        window.location.reload();
-      }
-
       return {...state, ...action.payload, ...{ connectionStatus : ConnectionStatus.Connected } };
     }
 


### PR DESCRIPTION
This gets Arc.js v38 which works-around issues with getting the default account when unlocking Metamask on application startup.

Also calls `InitialSchemesSet` instead of `NewOrg` when getting list of DAOs, to avoid getting corrupt DAOs.