### PR TITLE
add jest for automatic unit testing.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 node_modules/
 dist/
+coverage/
 kovan_pass.txt
 ropsten_pass.txt
 PRIVATE_README.md

--- a/package.json
+++ b/package.json
@@ -12,6 +12,33 @@
   "engines": {
     "node": "9.5"
   },
+  "jest": {
+    "transform": {
+      ".(ts|tsx)": "<rootDir>/node_modules/ts-jest/preprocessor.js"
+    },
+    "testPathIgnorePatterns": [
+      "/node_modules/",
+      "/lib/"
+    ],
+    "testRegex": "(/test/.*|\\.(test|spec))\\.(ts|tsx|js)$",
+    "moduleFileExtensions": [
+      "ts",
+      "tsx",
+      "js",
+      "json"
+    ],
+    "moduleNameMapper": {
+      "\\.(scss|css|less)$": "identity-obj-proxy",
+      "^actions(.*)$": "<rootDir>/src/actions$1",
+      "^components(.*)$": "<rootDir>/src/components$1",
+      "^constants(.*)$": "<rootDir>/src/constants$1",
+      "^layouts(.*)$": "<rootDir>/src/layouts$1",
+      "^lib(.*)$": "<rootDir>/src/lib$1",
+      "^reducers(.*)$": "<rootDir>/src/reducers$1",
+      "^selectors(.*)$": "<rootDir>/src/selectors$1",
+      "^src(.*)$": "<rootDir>/src$1"
+    }
+  },
   "scripts": {
     "build": "cross-env NODE_ENV=production webpack --config webpack.prod.config.js",
     "heroku-postbuild": "npm run build",
@@ -22,6 +49,8 @@
     "ganacheDb-restore": "npm explore @daostack/arc.js -- npm start test.ganacheDb.restoreFromZip",
     "migrate-ganache": "cross-env network=ganache npm explore @daostack/arc.js -- npm start migrateContracts",
     "lint": "tslint --project .",
+    "test": "jest --coverage",
+    "test:watch": "jest --watch",
     "start": "webpack-dev-server --config webpack.dev.config.js",
     "start-ganache": "cross-env network=ganache npm run start",
     "start-kovan": "cross-env network=kovan npm run start",
@@ -44,7 +73,7 @@
     "react-dom": "^16.2.0",
     "react-redux": "^5.0.6",
     "react-router-dom": "^4.2.2",
-    "react-router-redux": "5.0.0-alpha.7",
+    "react-router-redux": "^5.0.0",
     "react-transition-group": "^2.2.1",
     "redux": "^3.7.2",
     "redux-devtools-extension": "^2.13.2",
@@ -62,6 +91,7 @@
   "devDependencies": {
     "@types/classnames": "^2.2.3",
     "@types/es6-promisify": "^5.0.0",
+    "@types/jest": "^22.2.0",
     "@types/lodash": "^4.14.74",
     "@types/node": "^8.0.26",
     "@types/react": "^16.0.35",
@@ -81,6 +111,8 @@
     "ganache-cli": "^6.0.3",
     "git-revision-webpack-plugin": "^2.5.1",
     "html-webpack-plugin": "^3.0.6",
+    "identity-obj-proxy": "^3.0.0",
+    "jest": "^22.4.2",
     "node-sass": "^4.5.3",
     "react-hot-loader": "^3.0.0-beta.7",
     "sass-loader": "^6.0.6",
@@ -88,6 +120,7 @@
     "source-map-loader": "^0.2.1",
     "tslint": "^5.9.1",
     "tslint-react": "^3.5.1",
+    "ts-jest": "^22.4.1",
     "typescript": "^2.7",
     "typings-for-css-modules-loader": "^1.5.0",
     "uglifyjs-webpack-plugin": "^1.2.2",

--- a/src/App.spec.tsx
+++ b/src/App.spec.tsx
@@ -1,0 +1,8 @@
+import {render} from 'react-dom';
+import * as React from 'react';
+import { App } from './App';
+
+it('renders without crashing', () => {
+  const div = document.createElement('div');
+  render(<App />, div);
+});

--- a/src/reducers/notificationsReducer.spec.ts
+++ b/src/reducers/notificationsReducer.spec.ts
@@ -1,0 +1,22 @@
+import notificationsReducer, { ActionTypes } from './notificationsReducer';
+
+describe('notificationsReducer', () => {
+  it('should perform state transitions correctly', () => {
+    const prev = {alert: Math.random().toString()};
+    const next = {alert: Math.random().toString()};
+
+    expect(
+      notificationsReducer(
+        prev,
+        {type: ActionTypes.ALERT_SHOW, payload: next}
+      )
+    ).toEqual(next);
+
+    expect(
+      notificationsReducer(
+        prev,
+        {type: Math.random().toString}
+      )
+    ).toEqual({alert: ''});
+  })
+});

--- a/tslint.json
+++ b/tslint.json
@@ -21,13 +21,18 @@
         "jsx-alignment": false,
         "jsx-wrap-multiline": false,
         "jsx-no-lambda": false,
+        "jsx-curly-spacing": false,
         "no-shadowed-variable": false,
         "no-empty": false,
         "no-empty-interface": false,
         "interface-name": false,
         "prefer-const": false,
         "comment-format": false,
-        "no-unused-expression": false
+        "no-unused-expression": false,
+        "quotemark": false,
+        "ordered-imports": false,
+        "trailing-comma": false,
+        "semicolon": false
     },
     "rulesDirectory": []
 }


### PR DESCRIPTION
Changes:
- added `jest` along with other deps, configuration for `jest` is in `package.json["jest"]`.
- two simple tests to make sure it's all working: [`reducers/notificationsReducer.spec.ts`,`App.spec.tsx`].

Commands:
- `npm run test`
- `npm run test:watch` - rerun relevant tests upon file changes.

Jest also generates coverage reports (in `coverage/`), which can be useful.