### PR TITLE
CI/CD

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,16 @@
+language: node_js
+node_js: 9.5.0
+
+script:
+- npm run lint
+- npm run test
+- npm run build
+
+deploy:
+  provider: pages
+  skip-cleanup: true
+  github-token: $GH_TOKEN
+  keep-history: true
+  local-dir: dist
+  on:
+    branch: master


### PR DESCRIPTION
Resolve #33.
Integrate travis into the project for automatic: lint, test, build and deploy to `gh-pages`.

**Further Prep: 
Please make sure to enable travis at https://travis-ci.org/ and to include the `GH_TOKEN` env variable to allow travis to deploy to `gh-pages`**