### PR TITLE
detect gananche network name

### DIFF
--- a/src/lib/util.ts
+++ b/src/lib/util.ts
@@ -11,17 +11,19 @@ export default class Util {
   public static networkName(id: number) {
     switch (id) {
       case 1:
-        return "mainnet"
+        return "Mainnet"
       case 2:
-        return "morden"
+        return "Morden"
       case 3:
-        return "ropsten"
+        return "Ropsten"
       case 4:
-        return "rinkeby"
+        return "Rinkeby"
       case 42:
-        return "kovan"
+        return "Kovan"
+      case 1512051714758:
+        return "Ganache"
       default:
-        return "unknown network"
+        return "Unknown network"
     }
   }
 }


### PR DESCRIPTION
As I said in trello, `ganache-cli` doesn't have a const `networkId`, but arc.js does provide one.