### PR TITLE
fix update tokens/rep bug

### DIFF
--- a/src/reducers/arcReducer.ts
+++ b/src/reducers/arcReducer.ts
@@ -304,7 +304,7 @@ const arcReducer = (state = initialState, action: any) => {
             members: {
               [to]: (member: any) => {
                 // If tokens are being given to a non member, add them as a member to this DAO
-                update(member || { address: to, tokens: 0, reputation: 0, votes: {}, stakes: {} }, {
+                return update(member || { address: to, tokens: 0, reputation: 0, votes: {}, stakes: {} }, {
                   tokens: { $set: toBalance }
                 });
               },
@@ -324,7 +324,7 @@ const arcReducer = (state = initialState, action: any) => {
             members: {
               [address]: (member: any) => {
                 // If reputation being given to a non member, add them as a member to this DAO
-                update(member || { address, tokens: 0, reputation: 0, votes: {}, stakes: {} }, {
+                return update(member || { address, tokens: 0, reputation: 0, votes: {}, stakes: {} }, {
                   tokens: { $set: reputation }
                 });
               },


### PR DESCRIPTION
The lack of `return` in the function inside `update` made the reducer effectively remove the member from the dao, because it was returning undefined.