### PR TITLE
Change Arc.js version to get rid of mock DAOs

### DIFF
--- a/package.json
+++ b/package.json
@@ -59,7 +59,7 @@
     "auto-start-ganache": "cross-env arcjs_network=ganache run-with-ganache --ganache-cmd ganache-cli \"npm run migrate-ganache && npm run start-ganache\""
   },
   "dependencies": {
-    "@daostack/arc.js": "0.0.0-alpha.47",
+    "@daostack/arc.js": "0.0.0-alpha.48.1",
     "@types/object-hash": "^1.2.0",
     "aws-sdk": "^2.212.1",
     "axios": "^0.17.1",


### PR DESCRIPTION
This version of arc.js is the same as `.47` but with a a fresh migration of the contracts, so we don't have all the mock DAOs (Skynet thing).