### PR TITLE
Fix 'stuck on pending'

### DIFF
--- a/src/components/Proposal/PredictionBox.tsx
+++ b/src/components/Proposal/PredictionBox.tsx
@@ -72,12 +72,12 @@ export default class PredictionBox extends React.Component<IProps, IState> {
 
     const passPrediction = classNames({
       [css.passPrediction]: true,
-      [css.disabled]: !currentAccountTokens,
+      [css.disabled]: !currentAccountTokens || currentPrediction === VoteOptions.No,
     });
 
     const failPrediction = classNames({
       [css.failPrediction]: true,
-      [css.disabled]: !currentAccountTokens,
+      [css.disabled]: !currentAccountTokens || currentPrediction === VoteOptions.Yes,
     });
 
     return (


### PR DESCRIPTION
This happens because of https://github.com/daostack/arc.js/issues/215. A work-around is possible until there's a new version. But in certain cases it might be solved with a simple UI fix.

- When staking, disable staking on a different prediction than the one already staked on.
- Is there other cases in which this happens?