### PR TITLE
Fix operation handling

### DIFF
--- a/src/actions/arcActions.ts
+++ b/src/actions/arcActions.ts
@@ -446,9 +446,9 @@ export type CreateDAOAction = IAsyncAction<'ARC_CREATE_DAO', {}, any>;
 export function createDAO(daoName: string, tokenName: string, tokenSymbol: string, members: any): ThunkAction<any, IRootState, null> {
   return async (dispatch: Redux.Dispatch<any>, getState: () => IRootState) => {
     try {
-      let founders: Arc.FounderConfig[] = [], member: IAccountState,
-          membersByAccount: { [key: string]: IAccountState } = {},
-          totalReputation = 0, totalTokens = 0;
+      let founders: Arc.FounderConfig[] = [], member: IAccountState;
+      let membersByAccount: { [key: string]: IAccountState } = {};
+      let totalReputation = 0, totalTokens = 0;
 
       members.sort((a: any, b: any) => {
         b.reputation - a.reputation;
@@ -494,6 +494,15 @@ export function createDAO(daoName: string, tokenName: string, tokenSymbol: strin
             operation: {
               message: 'Creating new DAO...',
               totalSteps
+            }
+          } as CreateDAOAction),
+        (txInfo: any) =>
+          dispatch({
+            type: arcConstants.ARC_CREATE_DAO,
+            sequence: AsyncActionSequence.Pending,
+            operation: {
+              message: 'Creating new DAO...',
+              totalSteps: txInfo.txCount
             }
           } as CreateDAOAction)
       );

--- a/src/actions/arcActions.ts
+++ b/src/actions/arcActions.ts
@@ -597,7 +597,8 @@ export function createProposal(daoAvatarAddress: string, title: string, descript
           periodLength: 1,
           reputationChange: Util.toWei(reputationReward),
         },
-        (totalSteps: number) =>
+        // Kickoff event
+        (totalSteps: number) => {
           dispatch({
             type: arcConstants.ARC_CREATE_PROPOSAL,
             sequence: AsyncActionSequence.Pending,
@@ -606,10 +607,12 @@ export function createProposal(daoAvatarAddress: string, title: string, descript
               totalSteps,
             },
             meta,
-          } as CreateProposalAction)
-      );
+          } as CreateProposalAction);
 
-      dispatch(push("/dao/" + daoAvatarAddress));
+          // Go back to home page while action create proposal operation gets carried out
+          dispatch(push("/dao/" + daoAvatarAddress));
+        }
+      );
     } catch (err) {
       console.error(err);
       dispatch({

--- a/src/actions/arcActions.ts
+++ b/src/actions/arcActions.ts
@@ -926,6 +926,16 @@ export function stakeProposal(daoAvatarAddress: string, proposalId: string, pred
               totalSteps,
             },
             meta
+          } as StakeAction),
+        (txInfo: any) =>
+          dispatch({
+            type: arcConstants.ARC_STAKE,
+            sequence: AsyncActionSequence.Pending,
+            operation: {
+              message: `Staking on "${proposal.title}" ...`,
+              totalSteps: txInfo.txCount,
+            },
+            meta
           } as StakeAction)
       );
     } catch (err) {

--- a/src/reducers/operations.ts
+++ b/src/reducers/operations.ts
@@ -42,7 +42,7 @@ export const operationsReducer =
         const defaults: IOperation = {
           status: action.sequence == AsyncActionSequence.Pending ? OperationsStatus.Pending : OperationsStatus.Failure,
           message: operationsConfig.message || `Operation #${hash.substr(0, 4)}`,
-          step: 0,
+          step: -1,
           totalSteps: operationsConfig.totalSteps,
           timestamp: +moment() // TODO: this makes the reducer impure. figure out a better way.
         }


### PR DESCRIPTION
Fix how subscriptions to the Arc.js transaction service for Alchemy operations

We now fire two separate callbacks, one before any of the transactions are actually started (onKickoff) and one after each transaction completes (onTransaction).

This allows us to show the first notification at the appropriate time

Handle multi-step operations better, like staking
At beginning show step as  0 of 2, then the operation is complete at 2 of 2