### PR TITLE
fix cannot read .. bug

### DIFF
--- a/src/reducers/arcReducer.ts
+++ b/src/reducers/arcReducer.ts
@@ -262,7 +262,7 @@ const arcReducer = (state = initialState, action: any) => {
 
   switch (action.type) {
     case ActionTypes.ARC_LOAD_CACHED_STATE_FULFILLED: {
-      return payload;
+      return {...initialState, ...payload};
     }
 
     case ActionTypes.ARC_GET_DAOS_FULFILLED: {


### PR DESCRIPTION
Fix:
```
Uncaught TypeError: Cannot read property '0xb0c908140fe6fd6fbd4990a5c2e35ca6dc12bfb2-0xf7b7be05d6c115184f78226f905b643dd577fa6b' of undefined
    at Function.mapStateToProps [as mapToProps] (VM21136 HeaderContainer.tsx:39)
    at mapToPropsProxy (wrapMapToProps.js?9b64:43)
    at Function.detectFactoryAndVerify (wrapMapToProps.js?9b64:52)
    at mapToPropsProxy (wrapMapToProps.js?9b64:43)
    at handleFirstCall (selectorFactory.js?3100:26)
    at pureFinalPropsSelector (selectorFactory.js?3100:74)
    at Object.runComponentSelector [as run] (connectAdvanced.js?b499:26)
    at ProxyComponent.initSelector (connectAdvanced.js?b499:178)
    at ProxyComponent.initSelector (createPrototypeProxy.js?e4a7:44)
    at ProxyComponent.Connect (connectAdvanced.js?b499:119)
```