### PR TITLE
Fix build bug causing cache script to fail

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -10,6 +10,6 @@
   },
   "include": [
     "./src/**/*",
-    "./typings/*", "scripts/populateDAO.ts"
+    "./typings/*"
   ]
 }


### PR DESCRIPTION
including `scripts/populateDAO.ts` in `tsconfig.json` makes typescript output a different directory structure that causes the cache script to fail not finding the file `dist/bg_cache_worker.js`. Note: This was already deployed to production and works successfully.