### PR TITLE
Add basic DAO-chosen headings

### DIFF
--- a/src/components/ViewDao/DaoHeadings.tsx
+++ b/src/components/ViewDao/DaoHeadings.tsx
@@ -15,6 +15,7 @@ export default class DaoHeadings extends React.Component<IProps, null> {
 
   public render() {
     const { dao } = this.props;
+    console.log(dao);
 
     var latestHeadingProposal = {
       executionTime: 0,

--- a/src/components/ViewDao/DaoHeadings.tsx
+++ b/src/components/ViewDao/DaoHeadings.tsx
@@ -15,8 +15,13 @@ export default class DaoHeadings extends React.Component<IProps, null> {
 
   public render() {
     const { dao } = this.props;
+    console.log(dao);
 
-    var latestHeadingProposal = { executionTime: 0, title: "DAO Heading: Placeholder heading" };
+    var latestHeadingProposal = {
+      executionTime: 0,
+      title: 'DAO Heading: Pass a proposal with a title that starts with \
+             "DAO Heading:" to replace this text.'
+    };
 
     dao.proposals.forEach((proposal: IProposalState) => {
       if(proposal.executionTime > latestHeadingProposal.executionTime &&
@@ -24,7 +29,7 @@ export default class DaoHeadings extends React.Component<IProps, null> {
         latestHeadingProposal = proposal;
       }
     });
-
+    
     return (
       <div className={css.daoHeadings + " " + css.clearfix}>
         { latestHeadingProposal.title.slice(13) }

--- a/src/components/ViewDao/DaoHeadings.tsx
+++ b/src/components/ViewDao/DaoHeadings.tsx
@@ -1,0 +1,34 @@
+import * as classNames from "classnames";
+import * as React from "react";
+import { Link } from "react-router-dom";
+
+import * as arcActions from "actions/arcActions";
+import { IDaoState, IProposalState } from "reducers/arcReducer";
+
+import * as css from "./ViewDao.scss";
+
+interface IProps {
+  dao: IDaoState;
+}
+
+export default class DaoHeadings extends React.Component<IProps, null> {
+
+  public render() {
+    const { dao } = this.props;
+
+    var latestHeadingProposal = { executionTime: 0, title: "DAO Heading: Placeholder heading" };
+
+    dao.proposals.forEach((proposal: IProposalState) => {
+      if(proposal.executionTime > latestHeadingProposal.executionTime &&
+      proposal.title.slice(0, 12) === "DAO Heading:") {
+        latestHeadingProposal = proposal;
+      }
+    });
+
+    return (
+      <div className={css.daoHeadings + " " + css.clearfix}>
+        { latestHeadingProposal.title.slice(13) }
+      </div>
+    );
+  }
+}

--- a/src/components/ViewDao/DaoHeadings.tsx
+++ b/src/components/ViewDao/DaoHeadings.tsx
@@ -15,7 +15,6 @@ export default class DaoHeadings extends React.Component<IProps, null> {
 
   public render() {
     const { dao } = this.props;
-    console.log(dao);
 
     var latestHeadingProposal = {
       executionTime: 0,

--- a/src/components/ViewDao/DaoHeadings.tsx
+++ b/src/components/ViewDao/DaoHeadings.tsx
@@ -24,12 +24,12 @@ export default class DaoHeadings extends React.Component<IProps, null> {
     };
 
     dao.proposals.forEach((proposal: IProposalState) => {
-      if(proposal.executionTime > latestHeadingProposal.executionTime &&
-      proposal.title.slice(0, 12) === "DAO Heading:") {
-        latestHeadingProposal = proposal;
+      if (proposal.executionTime > latestHeadingProposal.executionTime &&
+          proposal.title.slice(0, 12) === "DAO Heading:") {
+            latestHeadingProposal = proposal;
       }
     });
-    
+
     return (
       <div className={css.daoHeadings + " " + css.clearfix}>
         { latestHeadingProposal.title.slice(13) }

--- a/src/components/ViewDao/ViewDao.scss
+++ b/src/components/ViewDao/ViewDao.scss
@@ -41,6 +41,10 @@ button:hover {
   padding: 30px 30px 5px 30px;
 }
 
+.daoHeadings {
+  padding: 30px 30px 5px 30px;
+}
+
 .nav {
   padding: 0 30px;
   position: relative;

--- a/src/components/ViewDao/ViewDao.scss.d.ts
+++ b/src/components/ViewDao/ViewDao.scss.d.ts
@@ -4,6 +4,7 @@ export const outer: string;
 export const top: string;
 export const loading: string;
 export const daoHeader: string;
+export const daoHeadings: string;
 export const nav: string;
 export const borderBottom: string;
 export const columnHeader: string;

--- a/src/components/ViewDao/ViewDaoContainer.tsx
+++ b/src/components/ViewDao/ViewDaoContainer.tsx
@@ -22,6 +22,7 @@ import * as schemas from "schemas";
 
 import ViewProposalContainer from "components/Proposal/ViewProposalContainer";
 import DaoHeader from "./DaoHeader";
+import DaoHeadings from "./DaoHeadings";
 import DaoHistoryContainer from "./DaoHistoryContainer";
 import DaoMembersContainer from "./DaoMembersContainer";
 import DaoNav from "./DaoNav";
@@ -430,6 +431,7 @@ For additional information check out our <a href="https://docs.google.com/docume
         />
         <div className={css.top}>
           <DaoHeader dao={dao} />
+          <DaoHeadings dao={dao} />
           <DaoNav currentAccountAddress={currentAccountAddress} dao={dao} numRedemptions={numRedemptions} />
         </div>
         <div className={css.wrapper}>


### PR DESCRIPTION
This is the fulfillment of a passed Genesis proposal for [DAO-chosen headings in Alchemy](https://docs.google.com/document/d/1g9CGhDRdcPffftwJmmdNa34umhrpudqzR77NW5SOG_U/edit).

From the proposal: 

> Create a prominent space in Alchemy UI where the Genesis DAO can display custom text. This text can be anything the DAO decides: a mission, objectives, an advertisement, and so on. This proposal demonstrates the process by putting in some placeholder text.

### What I did

Added a small section to the ViewDaoContainer that looks for the latest executed proposal with a title starting with "DAO Heading:" and displays the rest of that proposal's title underneath the header.

<img width="1365" alt="screen shot 2018-12-16 at 10 13 22 am" src="https://user-images.githubusercontent.com/5414803/50055307-497a3000-011b-11e9-8585-0158aada69dd.png">

_Disclaimer: I'm a beginner coder, so please help me correct my mistakes!_