### PR TITLE
upgrade client to 53

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -259,9 +259,9 @@
       }
     },
     "@daostack/client": {
-      "version": "0.0.52",
-      "resolved": "https://registry.npmjs.org/@daostack/client/-/client-0.0.52.tgz",
-      "integrity": "sha512-tMoYFoSWjC/5FirxlRlz9Tn3dKPxU811WxOiVpbxvanR4k/NLKXQX1s9u+IC08yJOOTjl8WbVvBezhKpRTOf1g==",
+      "version": "0.0.53",
+      "resolved": "https://registry.npmjs.org/@daostack/client/-/client-0.0.53.tgz",
+      "integrity": "sha512-jQJPdDAHIEHQt6nsNHgsF8+bKF3bMr8oFO6hJekjVv6sqORfREQHCORdLDNg7fAlnCtkAJSPV2Gvm9pO2e9uGg==",
       "requires": {
         "@daostack/arc": "0.0.1-rc.16",
         "apollo-cache-inmemory": "^1.5.1",

--- a/package.json
+++ b/package.json
@@ -62,7 +62,7 @@
     "test:integration:headless": "wdio ./test/integration/wdio-headless.conf.js"
   },
   "dependencies": {
-    "@daostack/client": "0.0.52",
+    "@daostack/client": "0.0.53",
     "@daostack/migration": "0.0.1-rc.16-v0",
     "@fortawesome/fontawesome-svg-core": "^1.2.10",
     "@fortawesome/free-brands-svg-icons": "^5.6.1",


### PR DESCRIPTION
this upgrade get allowance and balance directly from chain (instead of from the subgraph), so the subgraph can stop indexing GEN and we can have decently-timed updates