### PR TITLE
Dont check DAO external token balance when looking for proposal rewards

### DIFF
--- a/src/components/Proposal/ActionButton.tsx
+++ b/src/components/Proposal/ActionButton.tsx
@@ -96,13 +96,13 @@ class ActionButton extends React.Component<IProps, IState> {
     } = this.props;
 
     // TODO: should be the DAO balance of the proposal.externalToken
-    const externalTokenBalance = dao.externalTokenBalance || new BN(0);
+    //const externalTokenBalance = dao.externalTokenBalance || new BN(0);
 
     const beneficiaryHasRewards = (
       !proposal.reputationReward.isZero() ||
       proposal.nativeTokenReward.gt(new BN(0)) ||
       (proposal.ethReward.gt(new BN(0)) && daoEthBalance.gte(proposal.ethReward)) ||
-      (proposal.externalTokenReward.gt(new BN(0)) && externalTokenBalance.gte(proposal.externalTokenReward))
+      (proposal.externalTokenReward.gt(new BN(0)))
     ) as boolean;
 
     const accountHasRewards = rewardsForCurrentUser.length !== 0;

--- a/src/lib/util.ts
+++ b/src/lib/util.ts
@@ -104,7 +104,7 @@ export function formatTokens(amountWei: BN, symbol?: string): string {
 }
 
 export function tokenSymbol(tokenAddress: string) {
-  let symbol = Object.keys(TOKENS).find((token) => TOKENS[token] === tokenAddress);
+  let symbol = Object.keys(TOKENS).find((token) => TOKENS[token].toLowerCase() === tokenAddress.toLowerCase());
   return symbol || "?";
 }
 


### PR DESCRIPTION
This was broken before, though probably to effecting anything since we are now redeeming CR rewards on proposal execute.

Also a little fix to correctly show external token symbols when known