### PR TITLE
Fix account profile saving again

### DIFF
--- a/src/components/Account/AccountProfileContainer.tsx
+++ b/src/components/Account/AccountProfileContainer.tsx
@@ -1,6 +1,6 @@
 import { IDAOState, IMemberState } from "@daostack/client";
 import * as profileActions from "actions/profilesActions";
-import { getArc } from "arc";
+import { checkMetaMaskAndWarn, getArc } from "arc";
 import BN = require("bn.js");
 import AccountImage from "components/Account/AccountImage";
 import OAuthLogin from "components/Account/OAuthLogin";
@@ -92,7 +92,9 @@ class AccountProfileContainer extends React.Component<IProps, null> {
   }
 
   public async handleSubmit(values: FormValues, { props, setSubmitting, setErrors }: any ) {
-    const { accountAddress, showNotification, updateProfile } = this.props;
+    const { accountAddress, currentAccountAddress, showNotification, updateProfile } = this.props;
+
+    if (!(await checkMetaMaskAndWarn(this.props.showNotification.bind(this)))) { return; }
 
     const web3 = await Util.getWeb3();
     const timestamp = new Date().getTime().toString();
@@ -105,8 +107,8 @@ class AccountProfileContainer extends React.Component<IProps, null> {
 
     // Create promise-based version of send
     const send = promisify(web3.currentProvider.send);
-    const params = [msg, accountAddress];
-    const result = await send({ method, params, accountAddress });
+    const params = [msg, currentAccountAddress];
+    const result = await send({ method, params, from: currentAccountAddress });
     if (result.error) {
       console.error("Signing canceled, data was not saved");
       showNotification(NotificationStatus.Failure, `Saving profile was canceled`);


### PR DESCRIPTION
We weren’t checking if user had enabled MetaMask. And needed to fix the from param to the .send call

FIxes https://daostack.tpondemand.com/RestUI/Board.aspx#page=board/5209716961861964288&appConfig=eyJhY2lkIjoiQjgzMTMzNDczNzlCMUI5QUE0RUE1NUVEOUQyQzdFNkIifQ==&boardPopup=bug/1020/silent