### PR TITLE
fix vertical modal positioning on mobile

### DIFF
--- a/src/components/Shared/SocialShareModal.scss
+++ b/src/components/Shared/SocialShareModal.scss
@@ -49,7 +49,7 @@
 
   .link {
     padding: 24px 30px 24px 30px;
-  
+
     .title {
       display: inline-block;
       height: 18px;
@@ -142,7 +142,22 @@
     }
 
     .socialSite:hover {
-      background-color: #e1ebf7;        
+      background-color: #e1ebf7;
     }
+  }
+}
+
+
+
+@media only screen and (max-width: 425px) {
+  .modalWindow {
+    width: 318px;
+    position: absolute;
+    left: 50%;
+    top: 20px;
+    transform: translate(-50%, 0);
+    transition: all .25s ease;
+    border-radius: 15px 15px 0 0;
+    z-index: 99999999999999999;
   }
 }

--- a/src/layouts/App.scss
+++ b/src/layouts/App.scss
@@ -457,13 +457,6 @@ body {
   background-color: rgba(0,0,0,.4);
 }
 
-.modal {
-  position: absolute;
-  top: 50%;
-  left: 50%;
-  transform: translate(-50%, -50%);
-}
-
 .modalBody {
   overflow: hidden;
 }

--- a/src/layouts/AppContainer.tsx
+++ b/src/layouts/AppContainer.tsx
@@ -171,7 +171,6 @@ class AppContainer extends React.Component<IProps, IState> {
             </Switch>
 
             <ModalContainer
-              modalClassName={css.modal}
               backdropClassName={css.backdrop}
               containerClassName={css.modalContainer}
               bodyModalClassName={css.modalBody}


### PR DESCRIPTION
Addresses the vertical positioning issue with this popup and all others (Voters and PreTransaction).

See https://daostack.tpondemand.com/RestUI/Board.aspx#page=board/5209716961861964288&appConfig=eyJhY2lkIjoiQjgzMTMzNDczNzlCMUI5QUE0RUE1NUVEOUQyQzdFNkIifQ==&boardPopup=userstory/839/silent

And https://github.com/daostack/alchemy/issues/1041

Note this does not fully resolve the latter github issue, as that includes horizontal clipping and changing the mobile layouts of the other popups.