### PR TITLE
Links in proposal description should open in a new tab

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@
 ### Unreleased
 
   - Features Added
-    - ..
+    - Links in proposal description open in new tab
   - Bugs Fixed
     - Align headers of table in proposal history
     - Re-add redeem for beneficiary button to proposal details page

--- a/src/components/Proposal/ProposalDetailsPage.tsx
+++ b/src/components/Proposal/ProposalDetailsPage.tsx
@@ -188,7 +188,11 @@ class ProposalDetailsPage extends React.Component<IProps, IState> {
             </div>
 
             <div className={css.description}>
-              <ReactMarkdown source={proposal.description} />
+              <ReactMarkdown source={proposal.description}
+                renderers={{link: (props: { href: string; children: React.ReactNode }) => {
+                  return <a href={props.href} target="_blank" rel="noopener noreferrer">{props.children}</a>;
+                }}}
+              />
             </div>
 
             {url ?


### PR DESCRIPTION
Resolves: https://daostack.tpondemand.com/RestUI/Board.aspx#page=board/5209716961861964288&appConfig=eyJhY2lkIjoiQjgzMTMzNDczNzlCMUI5QUE0RUE1NUVEOUQyQzdFNkIifQ==&boardPopup=userstory/1565/silent