### PR TITLE
Cached provider should always be used when possible

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
     - Links in proposal description open in new tab
     - Show a message on startup when waiting for subgraph
     - Create a single place where all redemptions can be redeemed
+    - Cached provider, when available, is now always used when connecting to one's wallet
   - Bugs Fixed
     - Align headers of table in proposal history
     - Re-add redeem for beneficiary button to proposal details page

--- a/src/arc.ts
+++ b/src/arc.ts
@@ -412,7 +412,7 @@ async function enableWeb3Provider(provider?: any, blockOnWrongNetwork = true): P
  * @param provider Optional web3Provider
  * @return boolean whether Arc is successfully initialized.
  */
-export async function enableWeb3ProviderAndWarn(showNotification?: any, blockOnWrongNetwork = true): Promise<boolean> {
+async function enableWeb3ProviderAndWarn(showNotification?: any, blockOnWrongNetwork = true): Promise<boolean> {
   let success = false;
   let msg: string;
   try {
@@ -645,6 +645,22 @@ export async function loadCachedWeb3Provider(showNotification: any, notifyOnSucc
     return success;
   }
   return false;
+}
+
+export interface IEnableWWalletProviderParams {
+  blockOnWrongNetwork?: boolean;
+  notifyOnSuccess?: boolean;
+  showNotification: any;
+}
+
+/**
+ * load web3 wallet provider, first trying from cache, otherwise prompting
+ * @param options `IEnableWWalletProviderParams`
+ * @returns Promise of true on success
+ */
+export async function enableWalletProvider(options: IEnableWWalletProviderParams): Promise<boolean> {
+  return await loadCachedWeb3Provider(options.showNotification, options.notifyOnSuccess) ||
+         await enableWeb3ProviderAndWarn(options.showNotification, options.blockOnWrongNetwork);
 }
 
 // cf. https://github.com/MetaMask/faq/blob/master/DEVELOPERS.md#ear-listening-for-selected-account-changes

--- a/src/arc.ts
+++ b/src/arc.ts
@@ -576,39 +576,39 @@ export function getAccountIsEnabled(): boolean {
   return !!getWeb3Provider();
 }
 
-const ACCOUNTSTORAGEKEY = "currentAddress";
-const WALLETCONNECTSTORAGEKEY = "walletconnect";
-const PROVIDERSTORAGEKEY = "currentWeb3ProviderInfo";
+const ACCOUNT_STORAGEKEY = "currentAddress";
+const WALLETCONNECT_STORAGEKEY = "walletconnect";
+const PROVIDER_STORAGEKEY = "currentWeb3ProviderInfo";
 
 export function cacheWeb3Info(account: Address): void {
   if (account) {
-    localStorage.setItem(ACCOUNTSTORAGEKEY, account);
+    localStorage.setItem(ACCOUNT_STORAGEKEY, account);
   } else {
-    localStorage.removeItem(ACCOUNTSTORAGEKEY);
+    localStorage.removeItem(ACCOUNT_STORAGEKEY);
   }
   const providerInfo = getWeb3ProviderInfo();
   if (providerInfo) {
-    localStorage.setItem(PROVIDERSTORAGEKEY, JSON.stringify(providerInfo));
+    localStorage.setItem(PROVIDER_STORAGEKEY, JSON.stringify(providerInfo));
   } else {
-    localStorage.removeItem(PROVIDERSTORAGEKEY);
+    localStorage.removeItem(PROVIDER_STORAGEKEY);
     // hack until fixed by WalletConnect (so after logging out, can rescan the QR code)
-    localStorage.removeItem(WALLETCONNECTSTORAGEKEY);
+    localStorage.removeItem(WALLETCONNECT_STORAGEKEY);
   }
 }
 
 export function uncacheWeb3Info(): void {
-  localStorage.removeItem(ACCOUNTSTORAGEKEY);
-  localStorage.removeItem(PROVIDERSTORAGEKEY);
+  localStorage.removeItem(ACCOUNT_STORAGEKEY);
+  localStorage.removeItem(PROVIDER_STORAGEKEY);
   // hack until fixed by WalletConnect (so after logging out, can rescan the QR code)
-  localStorage.removeItem(WALLETCONNECTSTORAGEKEY);
+  localStorage.removeItem(WALLETCONNECT_STORAGEKEY);
 }
 
 export function getCachedAccount(): Address | null {
-  return localStorage.getItem(ACCOUNTSTORAGEKEY);
+  return localStorage.getItem(ACCOUNT_STORAGEKEY);
 }
 
 export function getCachedWeb3ProviderInfo(): IWeb3ProviderInfo | null {
-  const cached = localStorage.getItem(PROVIDERSTORAGEKEY);
+  const cached = localStorage.getItem(PROVIDER_STORAGEKEY);
   return cached ? JSON.parse(cached) : null;
 }
 

--- a/src/arc.ts
+++ b/src/arc.ts
@@ -485,15 +485,15 @@ export async function gotoReadonly(showNotification?: any): Promise<boolean> {
  *
  * This is meant to be used to bypass allowing the user to select a provider in the
  * case where we are initializing the app from a previously-cached (selected) provider.
+ * Thrown exceptions will be reported as notifications to the user
  * @param web3ProviderInfo required IWeb3ProviderInfo
  * @returns whether Arc has been successfully initialized.
  */
-export async function setWeb3ProviderAndWarn(web3ProviderInfo: IWeb3ProviderInfo, showNotification?: any): Promise<boolean> {
+export async function setWeb3ProviderAndWarn(
+  web3ProviderInfo: IWeb3ProviderInfo,
+  showNotification: any,
+  notifyOnSuccess = true): Promise<boolean> {
   let provider: any;
-
-  /**
-   * note the thrown exceptions will be reported as notifications to the user
-   */
 
   let success = false;
   let msg: string;
@@ -546,7 +546,7 @@ export async function setWeb3ProviderAndWarn(web3ProviderInfo: IWeb3ProviderInfo
 
     success = provider ? await enableWeb3Provider(provider, false) : false;
 
-    if (success && showNotification) {
+    if (success && showNotification && notifyOnSuccess) {
       showNotification(NotificationStatus.Success, `Connected to ${web3ProviderInfo.name}`);
     }
 
@@ -612,7 +612,7 @@ export function getCachedWeb3ProviderInfo(): IWeb3ProviderInfo | null {
   return cached ? JSON.parse(cached) : null;
 }
 
-export async function loadCachedWeb3Provider(showNotification: any): Promise<boolean> {
+export async function loadCachedWeb3Provider(showNotification: any, notifyOnSuccess = true): Promise<boolean> {
   const web3ProviderInfo = getCachedWeb3ProviderInfo();
   if (web3ProviderInfo) {
     /**
@@ -630,7 +630,7 @@ export async function loadCachedWeb3Provider(showNotification: any): Promise<boo
      * we'll pick up below.
      */
     try {
-      if (await setWeb3ProviderAndWarn(web3ProviderInfo, showNotification)) {
+      if (await setWeb3ProviderAndWarn(web3ProviderInfo, showNotification, notifyOnSuccess)) {
         // eslint-disable-next-line no-console
         console.log("using cached web3Provider");
         success = true;

--- a/src/arc.ts
+++ b/src/arc.ts
@@ -489,7 +489,7 @@ export async function gotoReadonly(showNotification?: any): Promise<boolean> {
  * @param web3ProviderInfo required IWeb3ProviderInfo
  * @returns whether Arc has been successfully initialized.
  */
-export async function setWeb3ProviderAndWarn(
+async function setWeb3ProviderAndWarn(
   web3ProviderInfo: IWeb3ProviderInfo,
   showNotification: any,
   notifyOnSuccess = true): Promise<boolean> {

--- a/src/components/Account/AccountProfilePage.tsx
+++ b/src/components/Account/AccountProfilePage.tsx
@@ -1,7 +1,7 @@
 import { promisify } from "util";
 import { IDAOState, IMemberState } from "@daostack/client";
 import * as profileActions from "actions/profilesActions";
-import { enableWeb3ProviderAndWarn, getArc, getWeb3Provider, getWeb3ProviderInfo } from "arc";
+import { enableWeb3ProviderAndWarn, getArc, getWeb3Provider, getWeb3ProviderInfo, loadCachedWeb3Provider } from "arc";
 
 import BN = require("bn.js");
 import AccountImage from "components/Account/AccountImage";
@@ -95,7 +95,8 @@ class AccountProfilePage extends React.Component<IProps, null> {
   public async handleSubmit(values: IFormValues, { _props, setSubmitting, _setErrors }: any): Promise<void> {
     const { accountAddress, currentAccountAddress, showNotification, updateProfile } = this.props;
 
-    if (!(await enableWeb3ProviderAndWarn(this.props.showNotification))) { return; }
+    if (!await loadCachedWeb3Provider(showNotification) &&
+        !await enableWeb3ProviderAndWarn(showNotification)) { return; }
 
     const web3Provider = await getWeb3Provider();
     try {

--- a/src/components/Account/AccountProfilePage.tsx
+++ b/src/components/Account/AccountProfilePage.tsx
@@ -1,7 +1,7 @@
 import { promisify } from "util";
 import { IDAOState, IMemberState } from "@daostack/client";
 import * as profileActions from "actions/profilesActions";
-import { enableWeb3ProviderAndWarn, getArc, getWeb3Provider, getWeb3ProviderInfo, loadCachedWeb3Provider } from "arc";
+import { getArc, getWeb3Provider, getWeb3ProviderInfo, enableWalletProvider } from "arc";
 
 import BN = require("bn.js");
 import AccountImage from "components/Account/AccountImage";
@@ -95,8 +95,7 @@ class AccountProfilePage extends React.Component<IProps, null> {
   public async handleSubmit(values: IFormValues, { _props, setSubmitting, _setErrors }: any): Promise<void> {
     const { accountAddress, currentAccountAddress, showNotification, updateProfile } = this.props;
 
-    if (!await loadCachedWeb3Provider(showNotification) &&
-        !await enableWeb3ProviderAndWarn(showNotification)) { return; }
+    if (!await enableWalletProvider({ showNotification })) { return; }
 
     const web3Provider = await getWeb3Provider();
     try {

--- a/src/components/Account/AccountProfilePage.tsx
+++ b/src/components/Account/AccountProfilePage.tsx
@@ -95,7 +95,7 @@ class AccountProfilePage extends React.Component<IProps, null> {
   public async handleSubmit(values: IFormValues, { _props, setSubmitting, _setErrors }: any): Promise<void> {
     const { accountAddress, currentAccountAddress, showNotification, updateProfile } = this.props;
 
-    if (!(await enableWeb3ProviderAndWarn(this.props.showNotification.bind(this)))) { return; }
+    if (!(await enableWeb3ProviderAndWarn(this.props.showNotification))) { return; }
 
     const web3Provider = await getWeb3Provider();
     try {

--- a/src/components/Proposal/ActionButton.tsx
+++ b/src/components/Proposal/ActionButton.tsx
@@ -68,12 +68,12 @@ class ActionButton extends React.Component<IProps, IState> {
   }
 
   public async handleClickExecute(_event: any): Promise<void> {
-    if (!(await enableWeb3ProviderAndWarn(this.props.showNotification.bind(this)))) { return; }
+    if (!(await enableWeb3ProviderAndWarn(this.props.showNotification))) { return; }
     await this.props.executeProposal(this.props.daoState.address, this.props.proposalState.id, this.props.currentAccountAddress);
   }
 
   public async handleClickRedeem(_event: any): Promise<void> {
-    if (!(await enableWeb3ProviderAndWarn(this.props.showNotification.bind(this)))) { return; }
+    if (!(await enableWeb3ProviderAndWarn(this.props.showNotification))) { return; }
     this.setState({ preRedeemModalOpen: true });
   }
 
@@ -202,7 +202,7 @@ class ActionButton extends React.Component<IProps, IState> {
   private async handleRedeemProposal(): Promise<void> {
 
     // may not be required, but just in case
-    if (!(await enableWeb3ProviderAndWarn(this.props.showNotification.bind(this)))) { return; }
+    if (!(await enableWeb3ProviderAndWarn(this.props.showNotification))) { return; }
 
     const {
       currentAccountAddress,

--- a/src/components/Proposal/ActionButton.tsx
+++ b/src/components/Proposal/ActionButton.tsx
@@ -1,6 +1,6 @@
 import { Address, IDAOState, IProposalOutcome, IProposalStage, IProposalState, IRewardState } from "@daostack/client";
 import { executeProposal, redeemProposal } from "actions/arcActions";
-import { enableWeb3ProviderAndWarn, loadCachedWeb3Provider } from "arc";
+import { enableWalletProvider } from "arc";
 import * as classNames from "classnames";
 import { ActionTypes, default as PreTransactionModal } from "components/Shared/PreTransactionModal";
 import { claimableContributionRewards, hasClaimableRewards } from "lib/util";
@@ -68,15 +68,13 @@ class ActionButton extends React.Component<IProps, IState> {
   }
 
   public async handleClickExecute(_event: any): Promise<void> {
-    if (!await loadCachedWeb3Provider(this.props.showNotification) &&
-        !await enableWeb3ProviderAndWarn(this.props.showNotification)) { return; }
+    if (!await enableWalletProvider({ showNotification: this.props.showNotification })) { return; }
 
     await this.props.executeProposal(this.props.daoState.address, this.props.proposalState.id, this.props.currentAccountAddress);
   }
 
   public async handleClickRedeem(_event: any): Promise<void> {
-    if (!await loadCachedWeb3Provider(this.props.showNotification) &&
-        !await enableWeb3ProviderAndWarn(this.props.showNotification)) { return; }
+    if (!await enableWalletProvider({ showNotification: this.props.showNotification })) { return; }
 
     this.setState({ preRedeemModalOpen: true });
   }
@@ -206,8 +204,7 @@ class ActionButton extends React.Component<IProps, IState> {
   private async handleRedeemProposal(): Promise<void> {
 
     // may not be required, but just in case
-    if (!await loadCachedWeb3Provider(this.props.showNotification) &&
-        !await enableWeb3ProviderAndWarn(this.props.showNotification)) { return; }
+    if (!await enableWalletProvider({ showNotification: this.props.showNotification })) { return; }
 
     const {
       currentAccountAddress,

--- a/src/components/Proposal/ActionButton.tsx
+++ b/src/components/Proposal/ActionButton.tsx
@@ -1,6 +1,6 @@
 import { Address, IDAOState, IProposalOutcome, IProposalStage, IProposalState, IRewardState } from "@daostack/client";
 import { executeProposal, redeemProposal } from "actions/arcActions";
-import { enableWeb3ProviderAndWarn } from "arc";
+import { enableWeb3ProviderAndWarn, loadCachedWeb3Provider } from "arc";
 import * as classNames from "classnames";
 import { ActionTypes, default as PreTransactionModal } from "components/Shared/PreTransactionModal";
 import { claimableContributionRewards, hasClaimableRewards } from "lib/util";
@@ -68,12 +68,16 @@ class ActionButton extends React.Component<IProps, IState> {
   }
 
   public async handleClickExecute(_event: any): Promise<void> {
-    if (!(await enableWeb3ProviderAndWarn(this.props.showNotification))) { return; }
+    if (!await loadCachedWeb3Provider(this.props.showNotification) &&
+        !await enableWeb3ProviderAndWarn(this.props.showNotification)) { return; }
+
     await this.props.executeProposal(this.props.daoState.address, this.props.proposalState.id, this.props.currentAccountAddress);
   }
 
   public async handleClickRedeem(_event: any): Promise<void> {
-    if (!(await enableWeb3ProviderAndWarn(this.props.showNotification))) { return; }
+    if (!await loadCachedWeb3Provider(this.props.showNotification) &&
+        !await enableWeb3ProviderAndWarn(this.props.showNotification)) { return; }
+
     this.setState({ preRedeemModalOpen: true });
   }
 
@@ -202,7 +206,8 @@ class ActionButton extends React.Component<IProps, IState> {
   private async handleRedeemProposal(): Promise<void> {
 
     // may not be required, but just in case
-    if (!(await enableWeb3ProviderAndWarn(this.props.showNotification))) { return; }
+    if (!await loadCachedWeb3Provider(this.props.showNotification) &&
+        !await enableWeb3ProviderAndWarn(this.props.showNotification)) { return; }
 
     const {
       currentAccountAddress,

--- a/src/components/Proposal/Create/SchemeForms/CreateContributionRewardProposal.tsx
+++ b/src/components/Proposal/Create/SchemeForms/CreateContributionRewardProposal.tsx
@@ -1,6 +1,6 @@
 import { IDAOState, ISchemeState } from "@daostack/client";
 import * as arcActions from "actions/arcActions";
-import { enableWeb3ProviderAndWarn, getArc } from "arc";
+import { enableWeb3ProviderAndWarn, getArc, loadCachedWeb3Provider } from "arc";
 import withSubscription, { ISubscriptionProps } from "components/Shared/withSubscription";
 import UserSearchField from "components/Shared/UserSearchField";
 import { ErrorMessage, Field, Form, Formik, FormikProps } from "formik";
@@ -92,7 +92,8 @@ class CreateContributionReward extends React.Component<IProps, null> {
   }
 
   public async handleSubmit(values: IFormValues, { setSubmitting }: any ): Promise<void> {
-    if (!(await enableWeb3ProviderAndWarn(this.props.showNotification))) { return; }
+    if (!await loadCachedWeb3Provider(this.props.showNotification) &&
+        !await enableWeb3ProviderAndWarn(this.props.showNotification)) { return; }
 
     if (!values.beneficiary.startsWith("0x")) { values.beneficiary = "0x" + values.beneficiary; }
 

--- a/src/components/Proposal/Create/SchemeForms/CreateContributionRewardProposal.tsx
+++ b/src/components/Proposal/Create/SchemeForms/CreateContributionRewardProposal.tsx
@@ -1,6 +1,6 @@
 import { IDAOState, ISchemeState } from "@daostack/client";
 import * as arcActions from "actions/arcActions";
-import { enableWeb3ProviderAndWarn, getArc, loadCachedWeb3Provider } from "arc";
+import { getArc, enableWalletProvider } from "arc";
 import withSubscription, { ISubscriptionProps } from "components/Shared/withSubscription";
 import UserSearchField from "components/Shared/UserSearchField";
 import { ErrorMessage, Field, Form, Formik, FormikProps } from "formik";
@@ -92,8 +92,7 @@ class CreateContributionReward extends React.Component<IProps, null> {
   }
 
   public async handleSubmit(values: IFormValues, { setSubmitting }: any ): Promise<void> {
-    if (!await loadCachedWeb3Provider(this.props.showNotification) &&
-        !await enableWeb3ProviderAndWarn(this.props.showNotification)) { return; }
+    if (!await enableWalletProvider({ showNotification: this.props.showNotification })) { return; }
 
     if (!values.beneficiary.startsWith("0x")) { values.beneficiary = "0x" + values.beneficiary; }
 

--- a/src/components/Proposal/Create/SchemeForms/CreateContributionRewardProposal.tsx
+++ b/src/components/Proposal/Create/SchemeForms/CreateContributionRewardProposal.tsx
@@ -1,6 +1,6 @@
 import { IDAOState, ISchemeState } from "@daostack/client";
 import * as arcActions from "actions/arcActions";
-import { getArc, enableWalletProvider } from "arc";
+import { enableWalletProvider, getArc } from "arc";
 import withSubscription, { ISubscriptionProps } from "components/Shared/withSubscription";
 import UserSearchField from "components/Shared/UserSearchField";
 import { ErrorMessage, Field, Form, Formik, FormikProps } from "formik";

--- a/src/components/Proposal/Create/SchemeForms/CreateKnownGenericSchemeProposal.tsx
+++ b/src/components/Proposal/Create/SchemeForms/CreateKnownGenericSchemeProposal.tsx
@@ -1,7 +1,7 @@
 // const BN = require("bn.js");
 import { IProposalType, ISchemeState } from "@daostack/client";
 import * as arcActions from "actions/arcActions";
-import { getArc, enableWalletProvider } from "arc";
+import { enableWalletProvider, getArc } from "arc";
 import * as classNames from "classnames";
 import { ErrorMessage, Field, FieldArray, Form, Formik, FormikErrors, FormikProps, FormikTouched } from "formik";
 import { Action, ActionField, GenericSchemeInfo } from "genericSchemeRegistry";

--- a/src/components/Proposal/Create/SchemeForms/CreateKnownGenericSchemeProposal.tsx
+++ b/src/components/Proposal/Create/SchemeForms/CreateKnownGenericSchemeProposal.tsx
@@ -1,7 +1,7 @@
 // const BN = require("bn.js");
 import { IProposalType, ISchemeState } from "@daostack/client";
 import * as arcActions from "actions/arcActions";
-import { enableWeb3ProviderAndWarn, getArc, loadCachedWeb3Provider } from "arc";
+import { getArc, enableWalletProvider } from "arc";
 import * as classNames from "classnames";
 import { ErrorMessage, Field, FieldArray, Form, Formik, FormikErrors, FormikProps, FormikTouched } from "formik";
 import { Action, ActionField, GenericSchemeInfo } from "genericSchemeRegistry";
@@ -68,8 +68,7 @@ class CreateKnownSchemeProposal extends React.Component<IProps, IState> {
   }
 
   public async handleSubmit(values: IFormValues, { setSubmitting }: any ): Promise<void> {
-    if (!await loadCachedWeb3Provider(this.props.showNotification) &&
-        !await enableWeb3ProviderAndWarn(this.props.showNotification)) { return; }
+    if (!await enableWalletProvider({ showNotification: this.props.showNotification })) { return; }
 
     const currentAction = this.state.currentAction;
 

--- a/src/components/Proposal/Create/SchemeForms/CreateKnownGenericSchemeProposal.tsx
+++ b/src/components/Proposal/Create/SchemeForms/CreateKnownGenericSchemeProposal.tsx
@@ -1,7 +1,7 @@
 // const BN = require("bn.js");
 import { IProposalType, ISchemeState } from "@daostack/client";
 import * as arcActions from "actions/arcActions";
-import { enableWeb3ProviderAndWarn, getArc } from "arc";
+import { enableWeb3ProviderAndWarn, getArc, loadCachedWeb3Provider } from "arc";
 import * as classNames from "classnames";
 import { ErrorMessage, Field, FieldArray, Form, Formik, FormikErrors, FormikProps, FormikTouched } from "formik";
 import { Action, ActionField, GenericSchemeInfo } from "genericSchemeRegistry";
@@ -68,7 +68,8 @@ class CreateKnownSchemeProposal extends React.Component<IProps, IState> {
   }
 
   public async handleSubmit(values: IFormValues, { setSubmitting }: any ): Promise<void> {
-    if (!(await enableWeb3ProviderAndWarn(this.props.showNotification))) { return; }
+    if (!await loadCachedWeb3Provider(this.props.showNotification) &&
+        !await enableWeb3ProviderAndWarn(this.props.showNotification)) { return; }
 
     const currentAction = this.state.currentAction;
 

--- a/src/components/Proposal/Create/SchemeForms/CreateSchemeRegistrarProposal.tsx
+++ b/src/components/Proposal/Create/SchemeForms/CreateSchemeRegistrarProposal.tsx
@@ -1,6 +1,6 @@
 import { IProposalType, ISchemeState, Scheme } from "@daostack/client";
 import * as arcActions from "actions/arcActions";
-import { enableWeb3ProviderAndWarn, getArc } from "arc";
+import { enableWeb3ProviderAndWarn, getArc, loadCachedWeb3Provider } from "arc";
 import * as classNames from "classnames";
 import Loading from "components/Shared/Loading";
 import withSubscription, { ISubscriptionProps } from "components/Shared/withSubscription";
@@ -64,7 +64,8 @@ class CreateSchemeRegistrarProposal extends React.Component<IProps, IState> {
   }
 
   public async handleSubmit(values: IFormValues, { setSubmitting }: any ):  Promise<void> {
-    if (!(await enableWeb3ProviderAndWarn(this.props.showNotification))) { return; }
+    if (!await loadCachedWeb3Provider(this.props.showNotification) &&
+        !await enableWeb3ProviderAndWarn(this.props.showNotification)) { return; }
 
     let permissions = 1;
     if (values.permissions.registerSchemes) {

--- a/src/components/Proposal/Create/SchemeForms/CreateSchemeRegistrarProposal.tsx
+++ b/src/components/Proposal/Create/SchemeForms/CreateSchemeRegistrarProposal.tsx
@@ -1,6 +1,6 @@
 import { IProposalType, ISchemeState, Scheme } from "@daostack/client";
 import * as arcActions from "actions/arcActions";
-import { enableWeb3ProviderAndWarn, getArc, loadCachedWeb3Provider } from "arc";
+import { getArc, enableWalletProvider } from "arc";
 import * as classNames from "classnames";
 import Loading from "components/Shared/Loading";
 import withSubscription, { ISubscriptionProps } from "components/Shared/withSubscription";
@@ -64,8 +64,7 @@ class CreateSchemeRegistrarProposal extends React.Component<IProps, IState> {
   }
 
   public async handleSubmit(values: IFormValues, { setSubmitting }: any ):  Promise<void> {
-    if (!await loadCachedWeb3Provider(this.props.showNotification) &&
-        !await enableWeb3ProviderAndWarn(this.props.showNotification)) { return; }
+    if (!await enableWalletProvider({ showNotification: this.props.showNotification })) { return; }
 
     let permissions = 1;
     if (values.permissions.registerSchemes) {

--- a/src/components/Proposal/Create/SchemeForms/CreateSchemeRegistrarProposal.tsx
+++ b/src/components/Proposal/Create/SchemeForms/CreateSchemeRegistrarProposal.tsx
@@ -1,6 +1,6 @@
 import { IProposalType, ISchemeState, Scheme } from "@daostack/client";
 import * as arcActions from "actions/arcActions";
-import { getArc, enableWalletProvider } from "arc";
+import { enableWalletProvider, getArc } from "arc";
 import * as classNames from "classnames";
 import Loading from "components/Shared/Loading";
 import withSubscription, { ISubscriptionProps } from "components/Shared/withSubscription";

--- a/src/components/Proposal/Create/SchemeForms/CreateUnknownGenericSchemeProposal.tsx
+++ b/src/components/Proposal/Create/SchemeForms/CreateUnknownGenericSchemeProposal.tsx
@@ -1,6 +1,6 @@
 import { ISchemeState } from "@daostack/client";
 import * as arcActions from "actions/arcActions";
-import { enableWeb3ProviderAndWarn, loadCachedWeb3Provider } from "arc";
+import { enableWalletProvider } from "arc";
 import { ErrorMessage, Field, Form, Formik, FormikProps } from "formik";
 import * as React from "react";
 import { connect } from "react-redux";
@@ -44,8 +44,7 @@ class CreateGenericScheme extends React.Component<IProps, null> {
   }
 
   public async handleSubmit(values: IFormValues, { setSubmitting }: any ): Promise<void> {
-    if (!await loadCachedWeb3Provider(this.props.showNotification) &&
-        !await enableWeb3ProviderAndWarn(this.props.showNotification)) { return; }
+    if (!await enableWalletProvider({ showNotification: this.props.showNotification })) { return; }
 
     const proposalValues = {...values,
       scheme: this.props.scheme.address,

--- a/src/components/Proposal/Create/SchemeForms/CreateUnknownGenericSchemeProposal.tsx
+++ b/src/components/Proposal/Create/SchemeForms/CreateUnknownGenericSchemeProposal.tsx
@@ -1,6 +1,6 @@
 import { ISchemeState } from "@daostack/client";
 import * as arcActions from "actions/arcActions";
-import { enableWeb3ProviderAndWarn } from "arc";
+import { enableWeb3ProviderAndWarn, loadCachedWeb3Provider } from "arc";
 import { ErrorMessage, Field, Form, Formik, FormikProps } from "formik";
 import * as React from "react";
 import { connect } from "react-redux";
@@ -44,7 +44,9 @@ class CreateGenericScheme extends React.Component<IProps, null> {
   }
 
   public async handleSubmit(values: IFormValues, { setSubmitting }: any ): Promise<void> {
-    if (!(await enableWeb3ProviderAndWarn(this.props.showNotification))) { return; }
+    if (!await loadCachedWeb3Provider(this.props.showNotification) &&
+        !await enableWeb3ProviderAndWarn(this.props.showNotification)) { return; }
+
     const proposalValues = {...values,
       scheme: this.props.scheme.address,
       dao: this.props.daoAvatarAddress,

--- a/src/components/Proposal/Staking/StakeButtons.tsx
+++ b/src/components/Proposal/Staking/StakeButtons.tsx
@@ -64,7 +64,7 @@ class StakeButtons extends React.Component<IProps, IState> {
   }
 
   public showApprovalModal = async (_event: any): Promise<void> => {
-    if ((await enableWeb3ProviderAndWarn(this.props.showNotification.bind(this)))) {
+    if ((await enableWeb3ProviderAndWarn(this.props.showNotification))) {
       this.setState({ showApproveModal: true });
     }
   }
@@ -79,14 +79,14 @@ class StakeButtons extends React.Component<IProps, IState> {
 
   public showPreStakeModal = (prediction: number): (_event: any) => void => (_event: any): void => {
     if (!this.props.currentAccountAddress) {
-      enableWeb3ProviderAndWarn(this.props.showNotification.bind(this));
+      enableWeb3ProviderAndWarn(this.props.showNotification);
     } else {
       this.setState({ pendingPrediction: prediction, showPreStakeModal: true });
     }
   }
 
   public handleClickPreApprove = async (_event: any): Promise<void> => {
-    if (!(await enableWeb3ProviderAndWarn(this.props.showNotification.bind(this)))) { return; }
+    if (!(await enableWeb3ProviderAndWarn(this.props.showNotification))) { return; }
     const { approveStakingGens } = this.props;
     approveStakingGens(this.props.proposal.votingMachine);
     this.setState({ showApproveModal: false });

--- a/src/components/Proposal/Staking/StakeButtons.tsx
+++ b/src/components/Proposal/Staking/StakeButtons.tsx
@@ -1,7 +1,7 @@
 import { Address, IDAOState, IProposalStage, IProposalState, Stake } from "@daostack/client";
 import * as arcActions from "actions/arcActions";
 import * as web3Actions from "actions/web3Actions";
-import { enableWeb3ProviderAndWarn } from "arc";
+import { enableWeb3ProviderAndWarn, loadCachedWeb3Provider } from "arc";
 
 import BN = require("bn.js");
 import * as classNames from "classnames";
@@ -64,9 +64,10 @@ class StakeButtons extends React.Component<IProps, IState> {
   }
 
   public showApprovalModal = async (_event: any): Promise<void> => {
-    if ((await enableWeb3ProviderAndWarn(this.props.showNotification))) {
-      this.setState({ showApproveModal: true });
-    }
+    if (!await loadCachedWeb3Provider(this.props.showNotification) &&
+        !await enableWeb3ProviderAndWarn(this.props.showNotification)) { return; }
+
+    this.setState({ showApproveModal: true });
   }
 
   public closeApprovalModal = (_event: any): void => {
@@ -86,7 +87,9 @@ class StakeButtons extends React.Component<IProps, IState> {
   }
 
   public handleClickPreApprove = async (_event: any): Promise<void> => {
-    if (!(await enableWeb3ProviderAndWarn(this.props.showNotification))) { return; }
+    if (!await loadCachedWeb3Provider(this.props.showNotification) &&
+        !await enableWeb3ProviderAndWarn(this.props.showNotification)) { return; }
+
     const { approveStakingGens } = this.props;
     approveStakingGens(this.props.proposal.votingMachine);
     this.setState({ showApproveModal: false });

--- a/src/components/Proposal/Staking/StakeButtons.tsx
+++ b/src/components/Proposal/Staking/StakeButtons.tsx
@@ -1,7 +1,7 @@
 import { Address, IDAOState, IProposalStage, IProposalState, Stake } from "@daostack/client";
 import * as arcActions from "actions/arcActions";
 import * as web3Actions from "actions/web3Actions";
-import { enableWeb3ProviderAndWarn, loadCachedWeb3Provider } from "arc";
+import { enableWalletProvider } from "arc";
 
 import BN = require("bn.js");
 import * as classNames from "classnames";
@@ -64,8 +64,7 @@ class StakeButtons extends React.Component<IProps, IState> {
   }
 
   public showApprovalModal = async (_event: any): Promise<void> => {
-    if (!await loadCachedWeb3Provider(this.props.showNotification) &&
-        !await enableWeb3ProviderAndWarn(this.props.showNotification)) { return; }
+    if (!await enableWalletProvider({ showNotification: this.props.showNotification })) { return; }
 
     this.setState({ showApproveModal: true });
   }
@@ -78,17 +77,13 @@ class StakeButtons extends React.Component<IProps, IState> {
     this.setState({ showPreStakeModal: false });
   }
 
-  public showPreStakeModal = (prediction: number): (_event: any) => void => (_event: any): void => {
-    if (!this.props.currentAccountAddress) {
-      enableWeb3ProviderAndWarn(this.props.showNotification);
-    } else {
-      this.setState({ pendingPrediction: prediction, showPreStakeModal: true });
-    }
+  public showPreStakeModal = (prediction: number): (_event: any) => void => async (_event: any): Promise<void> => {
+    if (!await enableWalletProvider( { showNotification: this.props.showNotification })) { return; }
+    this.setState({ pendingPrediction: prediction, showPreStakeModal: true });
   }
 
   public handleClickPreApprove = async (_event: any): Promise<void> => {
-    if (!await loadCachedWeb3Provider(this.props.showNotification) &&
-        !await enableWeb3ProviderAndWarn(this.props.showNotification)) { return; }
+    if (!await enableWalletProvider( { showNotification: this.props.showNotification })) { return; }
 
     const { approveStakingGens } = this.props;
     approveStakingGens(this.props.proposal.votingMachine);

--- a/src/components/Proposal/Voting/VoteBreakdown.tsx
+++ b/src/components/Proposal/Voting/VoteBreakdown.tsx
@@ -1,5 +1,5 @@
 import { Address, IDAOState, IMemberState, IProposalOutcome, IProposalState } from "@daostack/client";
-import { enableWeb3ProviderAndWarn } from "arc";
+import { enableWeb3ProviderAndWarn, loadCachedWeb3Provider } from "arc";
 
 import BN = require("bn.js");
 import * as classNames from "classnames";
@@ -46,7 +46,8 @@ class VoteBreakdown extends React.Component<IProps, IState> {
   }
 
   public async handleClickVote(vote: number, _event: any): Promise<void> {
-    if (!(await enableWeb3ProviderAndWarn(this.props.showNotification))) { return; }
+    if (!await loadCachedWeb3Provider(this.props.showNotification) &&
+        !await enableWeb3ProviderAndWarn(this.props.showNotification)) { return; }
 
     if (this.props.currentAccountState.reputation.gt(new BN(0))) {
       this.setState({ showPreVoteModal: true, currentVote: vote });

--- a/src/components/Proposal/Voting/VoteBreakdown.tsx
+++ b/src/components/Proposal/Voting/VoteBreakdown.tsx
@@ -1,5 +1,5 @@
 import { Address, IDAOState, IMemberState, IProposalOutcome, IProposalState } from "@daostack/client";
-import { enableWeb3ProviderAndWarn, loadCachedWeb3Provider } from "arc";
+import { enableWalletProvider } from "arc";
 
 import BN = require("bn.js");
 import * as classNames from "classnames";
@@ -46,8 +46,7 @@ class VoteBreakdown extends React.Component<IProps, IState> {
   }
 
   public async handleClickVote(vote: number, _event: any): Promise<void> {
-    if (!await loadCachedWeb3Provider(this.props.showNotification) &&
-        !await enableWeb3ProviderAndWarn(this.props.showNotification)) { return; }
+    if (!await enableWalletProvider({ showNotification: this.props.showNotification })) { return; }
 
     if (this.props.currentAccountState.reputation.gt(new BN(0))) {
       this.setState({ showPreVoteModal: true, currentVote: vote });

--- a/src/components/Proposal/Voting/VoteButtons.tsx
+++ b/src/components/Proposal/Voting/VoteButtons.tsx
@@ -1,6 +1,6 @@
 import { Address, IDAOState, IMemberState, IProposalOutcome, IProposalStage, IProposalState } from "@daostack/client";
 import * as arcActions from "actions/arcActions";
-import { enableWeb3ProviderAndWarn } from "arc";
+import { enableWeb3ProviderAndWarn, loadCachedWeb3Provider } from "arc";
 
 import BN = require("bn.js");
 import * as classNames from "classnames";
@@ -55,7 +55,8 @@ class VoteButtons extends React.Component<IProps, IState> {
   }
 
   public async handleClickVote(vote: number, _event: any): Promise<void> {
-    if (!(await enableWeb3ProviderAndWarn(this.props.showNotification))) { return; }
+    if (!await loadCachedWeb3Provider(this.props.showNotification) &&
+        !await enableWeb3ProviderAndWarn(this.props.showNotification)) { return; }
 
     const currentAccountState = this.props.currentAccountState;
     if (currentAccountState.reputation.gt(new BN(0))) {

--- a/src/components/Proposal/Voting/VoteButtons.tsx
+++ b/src/components/Proposal/Voting/VoteButtons.tsx
@@ -1,6 +1,6 @@
 import { Address, IDAOState, IMemberState, IProposalOutcome, IProposalStage, IProposalState } from "@daostack/client";
 import * as arcActions from "actions/arcActions";
-import { enableWeb3ProviderAndWarn, loadCachedWeb3Provider } from "arc";
+import { enableWalletProvider } from "arc";
 
 import BN = require("bn.js");
 import * as classNames from "classnames";
@@ -55,8 +55,7 @@ class VoteButtons extends React.Component<IProps, IState> {
   }
 
   public async handleClickVote(vote: number, _event: any): Promise<void> {
-    if (!await loadCachedWeb3Provider(this.props.showNotification) &&
-        !await enableWeb3ProviderAndWarn(this.props.showNotification)) { return; }
+    if (!await enableWalletProvider({ showNotification: this.props.showNotification })) { return; }
 
     const currentAccountState = this.props.currentAccountState;
     if (currentAccountState.reputation.gt(new BN(0))) {

--- a/src/components/Redemptions/RedemptionsMenu.tsx
+++ b/src/components/Redemptions/RedemptionsMenu.tsx
@@ -1,5 +1,5 @@
 import { Address, IDAOState, IProposalState, IRewardState, Proposal, Reward } from "@daostack/client";
-import { enableWeb3ProviderAndWarn, getArc, loadCachedWeb3Provider } from "arc";
+import { getArc, enableWalletProvider } from "arc";
 import * as arcActions from "actions/arcActions";
 
 import BN = require("bn.js");
@@ -93,8 +93,7 @@ class RedemptionsMenu extends React.Component<IProps, null> {
       showNotification,
     } = this.props;
 
-    if (!await loadCachedWeb3Provider(showNotification) &&
-        !await enableWeb3ProviderAndWarn(showNotification)) { return; }
+    if (!await enableWalletProvider({ showNotification })) { return; }
 
     redeemableProposals.forEach(proposal => {
       redeemProposal(proposal.dao.id, proposal.id, currentAccountAddress);

--- a/src/components/Redemptions/RedemptionsMenu.tsx
+++ b/src/components/Redemptions/RedemptionsMenu.tsx
@@ -1,5 +1,5 @@
 import { Address, IDAOState, IProposalState, IRewardState, Proposal, Reward } from "@daostack/client";
-import { getArc, enableWalletProvider } from "arc";
+import { enableWalletProvider, getArc } from "arc";
 import * as arcActions from "actions/arcActions";
 
 import BN = require("bn.js");

--- a/src/components/Redemptions/RedemptionsMenu.tsx
+++ b/src/components/Redemptions/RedemptionsMenu.tsx
@@ -1,5 +1,5 @@
 import { Address, IDAOState, IProposalState, IRewardState, Proposal, Reward } from "@daostack/client";
-import { enableWeb3ProviderAndWarn, getArc } from "arc";
+import { enableWeb3ProviderAndWarn, getArc, loadCachedWeb3Provider } from "arc";
 import * as arcActions from "actions/arcActions";
 
 import BN = require("bn.js");
@@ -93,7 +93,8 @@ class RedemptionsMenu extends React.Component<IProps, null> {
       showNotification,
     } = this.props;
 
-    if (!(await enableWeb3ProviderAndWarn(showNotification.bind(this)))) { return; }
+    if (!await loadCachedWeb3Provider(showNotification) &&
+        !await enableWeb3ProviderAndWarn(showNotification)) { return; }
 
     redeemableProposals.forEach(proposal => {
       redeemProposal(proposal.dao.id, proposal.id, currentAccountAddress);

--- a/src/components/Redemptions/RedemptionsPage.tsx
+++ b/src/components/Redemptions/RedemptionsPage.tsx
@@ -1,5 +1,5 @@
 import { Address, IDAOState, Proposal } from "@daostack/client";
-import { enableWeb3ProviderAndWarn, getArc, loadCachedWeb3Provider } from "arc";
+import { getArc, enableWalletProvider } from "arc";
 import * as arcActions from "actions/arcActions";
 
 import BN = require("bn.js");
@@ -97,8 +97,7 @@ class RedemptionsPage extends React.Component<IProps, null> {
       showNotification,
     } = this.props;
 
-    if (!await loadCachedWeb3Provider(showNotification) &&
-        !await enableWeb3ProviderAndWarn(showNotification)) { return; }
+    if (!await enableWalletProvider({ showNotification })) { return; }
 
     proposals.forEach(proposal => {
       redeemProposal(proposal.dao.id, proposal.id, currentAccountAddress);

--- a/src/components/Redemptions/RedemptionsPage.tsx
+++ b/src/components/Redemptions/RedemptionsPage.tsx
@@ -1,5 +1,5 @@
 import { Address, IDAOState, Proposal } from "@daostack/client";
-import { enableWeb3ProviderAndWarn, getArc } from "arc";
+import { enableWeb3ProviderAndWarn, getArc, loadCachedWeb3Provider } from "arc";
 import * as arcActions from "actions/arcActions";
 
 import BN = require("bn.js");
@@ -97,7 +97,8 @@ class RedemptionsPage extends React.Component<IProps, null> {
       showNotification,
     } = this.props;
 
-    if (!(await enableWeb3ProviderAndWarn(showNotification.bind(this)))) { return; }
+    if (!await loadCachedWeb3Provider(showNotification) &&
+        !await enableWeb3ProviderAndWarn(showNotification)) { return; }
 
     proposals.forEach(proposal => {
       redeemProposal(proposal.dao.id, proposal.id, currentAccountAddress);

--- a/src/components/Redemptions/RedemptionsPage.tsx
+++ b/src/components/Redemptions/RedemptionsPage.tsx
@@ -1,5 +1,5 @@
 import { Address, IDAOState, Proposal } from "@daostack/client";
-import { getArc, enableWalletProvider } from "arc";
+import { enableWalletProvider, getArc } from "arc";
 import * as arcActions from "actions/arcActions";
 
 import BN = require("bn.js");

--- a/src/components/Scheme/ReputationFromToken.tsx
+++ b/src/components/Scheme/ReputationFromToken.tsx
@@ -3,7 +3,7 @@ import * as queryString from "query-string";
 import { RouteComponentProps } from "react-router-dom";
 import { NotificationStatus } from "reducers/notifications";
 import { redeemReputationFromToken } from "actions/arcActions";
-import { enableWeb3ProviderAndWarn, getArc } from "arc";
+import { enableWeb3ProviderAndWarn, getArc, loadCachedWeb3Provider } from "arc";
 import { ErrorMessage, Field, Form, Formik, FormikProps } from "formik";
 import { schemeName, fromWei } from "lib/util";
 import * as React from "react";
@@ -130,7 +130,9 @@ class ReputationFromToken extends React.Component<IProps, IState> {
 
   public async handleSubmit(values: IFormValues, { _props, setSubmitting, _setErrors }: any): Promise<void> {
     // only connect to wallet if we do not have a private key to sign with
-    if (!this.state.privateKey && !(await enableWeb3ProviderAndWarn(this.props.showNotification))) {
+    if (!this.state.privateKey && 
+      !await loadCachedWeb3Provider(this.props.showNotification) &&
+      !await enableWeb3ProviderAndWarn(this.props.showNotification)) {
       setSubmitting(false);
       return;
     }

--- a/src/components/Scheme/ReputationFromToken.tsx
+++ b/src/components/Scheme/ReputationFromToken.tsx
@@ -130,7 +130,7 @@ class ReputationFromToken extends React.Component<IProps, IState> {
 
   public async handleSubmit(values: IFormValues, { _props, setSubmitting, _setErrors }: any): Promise<void> {
     // only connect to wallet if we do not have a private key to sign with
-    if (!this.state.privateKey && !(await enableWeb3ProviderAndWarn(this.props.showNotification.bind(this)))) {
+    if (!this.state.privateKey && !(await enableWeb3ProviderAndWarn(this.props.showNotification))) {
       setSubmitting(false);
       return;
     }
@@ -140,7 +140,7 @@ class ReputationFromToken extends React.Component<IProps, IState> {
     const arc = getArc();
     const schemeContract = await arc.getContract(schemeAddress);    const alreadyRedeemed = await schemeContract.methods.redeems(this.state.redeemerAddress).call();
     if (alreadyRedeemed) {
-      this.props.showNotification.bind(this)(NotificationStatus.Failure, `Reputation for the account ${this.state.redeemerAddress} was already redeemed`);
+      this.props.showNotification(NotificationStatus.Failure, `Reputation for the account ${this.state.redeemerAddress} was already redeemed`);
     } else {
       const scheme = arc.scheme(state.id);
       this.props.redeemReputationFromToken(scheme, values.accountAddress, this.state.privateKey, this.state.redeemerAddress);

--- a/src/components/Scheme/ReputationFromToken.tsx
+++ b/src/components/Scheme/ReputationFromToken.tsx
@@ -3,7 +3,7 @@ import * as queryString from "query-string";
 import { RouteComponentProps } from "react-router-dom";
 import { NotificationStatus } from "reducers/notifications";
 import { redeemReputationFromToken } from "actions/arcActions";
-import { enableWeb3ProviderAndWarn, getArc, loadCachedWeb3Provider } from "arc";
+import { enableWalletProvider, getArc } from "arc";
 import { ErrorMessage, Field, Form, Formik, FormikProps } from "formik";
 import { schemeName, fromWei } from "lib/util";
 import * as React from "react";
@@ -131,8 +131,7 @@ class ReputationFromToken extends React.Component<IProps, IState> {
   public async handleSubmit(values: IFormValues, { _props, setSubmitting, _setErrors }: any): Promise<void> {
     // only connect to wallet if we do not have a private key to sign with
     if (!this.state.privateKey && 
-      !await loadCachedWeb3Provider(this.props.showNotification) &&
-      !await enableWeb3ProviderAndWarn(this.props.showNotification)) {
+      !await enableWalletProvider({ showNotification: this.props.showNotification })) {
       setSubmitting(false);
       return;
     }

--- a/src/components/Scheme/SchemeContainer.tsx
+++ b/src/components/Scheme/SchemeContainer.tsx
@@ -1,6 +1,6 @@
 import * as H from "history";
 import { Address, ISchemeState } from "@daostack/client";
-import { enableWeb3ProviderAndWarn, getArc } from "arc";
+import { enableWeb3ProviderAndWarn, getArc, loadCachedWeb3Provider } from "arc";
 import * as classNames from "classnames";
 import Loading from "components/Shared/Loading";
 import withSubscription, { ISubscriptionProps } from "components/Shared/withSubscription";
@@ -52,10 +52,12 @@ class SchemeContainer extends React.Component<IProps, null> {
   public handleNewProposal = async (e: any): Promise<void> => {
     const { daoAvatarAddress, schemeId, showNotification } = this.props;
 
-    if ((await enableWeb3ProviderAndWarn(showNotification.bind(this)))) {
-      this.props.history.push(`/dao/${daoAvatarAddress}/scheme/${schemeId}/proposals/create`);
-    }
     e.preventDefault();
+
+    if (!await loadCachedWeb3Provider(showNotification) &&
+        !await enableWeb3ProviderAndWarn(showNotification)) { return; }
+
+    this.props.history.push(`/dao/${daoAvatarAddress}/scheme/${schemeId}/proposals/create/`);
   };
 
   public render(): RenderOutput {

--- a/src/components/Scheme/SchemeContainer.tsx
+++ b/src/components/Scheme/SchemeContainer.tsx
@@ -1,6 +1,6 @@
 import * as H from "history";
 import { Address, ISchemeState } from "@daostack/client";
-import { enableWeb3ProviderAndWarn, getArc, loadCachedWeb3Provider } from "arc";
+import { getArc, enableWalletProvider } from "arc";
 import * as classNames from "classnames";
 import Loading from "components/Shared/Loading";
 import withSubscription, { ISubscriptionProps } from "components/Shared/withSubscription";
@@ -54,8 +54,7 @@ class SchemeContainer extends React.Component<IProps, null> {
 
     e.preventDefault();
 
-    if (!await loadCachedWeb3Provider(showNotification) &&
-        !await enableWeb3ProviderAndWarn(showNotification)) { return; }
+    if (!await enableWalletProvider({ showNotification })) { return; }
 
     this.props.history.push(`/dao/${daoAvatarAddress}/scheme/${schemeId}/proposals/create/`);
   };

--- a/src/components/Scheme/SchemeContainer.tsx
+++ b/src/components/Scheme/SchemeContainer.tsx
@@ -1,6 +1,6 @@
 import * as H from "history";
 import { Address, ISchemeState } from "@daostack/client";
-import { getArc, enableWalletProvider } from "arc";
+import { enableWalletProvider, getArc } from "arc";
 import * as classNames from "classnames";
 import Loading from "components/Shared/Loading";
 import withSubscription, { ISubscriptionProps } from "components/Shared/withSubscription";

--- a/src/components/Scheme/SchemeProposalsPage.tsx
+++ b/src/components/Scheme/SchemeProposalsPage.tsx
@@ -57,7 +57,7 @@ const mapDispatchToProps = {
 class SchemeProposalsPage extends React.Component<IProps, null> {
 
   private async handleNewProposal(daoAvatarAddress: Address, schemeId: any): Promise<void> {
-    if ((await enableWeb3ProviderAndWarn(this.props.showNotification.bind(this)))) {
+    if ((await enableWeb3ProviderAndWarn(this.props.showNotification))) {
       this.props.history.push(`/dao/${daoAvatarAddress}/scheme/${schemeId}/proposals/create/`);
     }
   }

--- a/src/components/Scheme/SchemeProposalsPage.tsx
+++ b/src/components/Scheme/SchemeProposalsPage.tsx
@@ -1,6 +1,6 @@
 import * as H from "history";
 import { Address, IDAOState, IProposalStage, ISchemeState, Proposal } from "@daostack/client";
-import { getArc, enableWeb3ProviderAndWarn, loadCachedWeb3Provider } from "arc";
+import { getArc, enableWalletProvider } from "arc";
 import Loading from "components/Shared/Loading";
 import withSubscription, { ISubscriptionProps } from "components/Shared/withSubscription";
 import { schemeName} from "lib/util";
@@ -57,8 +57,7 @@ const mapDispatchToProps = {
 class SchemeProposalsPage extends React.Component<IProps, null> {
 
   private async handleNewProposal(daoAvatarAddress: Address, schemeId: any): Promise<void> {
-    if (!await loadCachedWeb3Provider(this.props.showNotification) &&
-        !await enableWeb3ProviderAndWarn(this.props.showNotification)) { return; }
+    if (!await enableWalletProvider({ showNotification: this.props.showNotification })) { return; }
 
     this.props.history.push(`/dao/${daoAvatarAddress}/scheme/${schemeId}/proposals/create/`);
   }

--- a/src/components/Scheme/SchemeProposalsPage.tsx
+++ b/src/components/Scheme/SchemeProposalsPage.tsx
@@ -1,6 +1,6 @@
 import * as H from "history";
 import { Address, IDAOState, IProposalStage, ISchemeState, Proposal } from "@daostack/client";
-import { getArc, enableWeb3ProviderAndWarn } from "arc";
+import { getArc, enableWeb3ProviderAndWarn, loadCachedWeb3Provider } from "arc";
 import Loading from "components/Shared/Loading";
 import withSubscription, { ISubscriptionProps } from "components/Shared/withSubscription";
 import { schemeName} from "lib/util";
@@ -57,9 +57,10 @@ const mapDispatchToProps = {
 class SchemeProposalsPage extends React.Component<IProps, null> {
 
   private async handleNewProposal(daoAvatarAddress: Address, schemeId: any): Promise<void> {
-    if ((await enableWeb3ProviderAndWarn(this.props.showNotification))) {
-      this.props.history.push(`/dao/${daoAvatarAddress}/scheme/${schemeId}/proposals/create/`);
-    }
+    if (!await loadCachedWeb3Provider(this.props.showNotification) &&
+        !await enableWeb3ProviderAndWarn(this.props.showNotification)) { return; }
+
+    this.props.history.push(`/dao/${daoAvatarAddress}/scheme/${schemeId}/proposals/create/`);
   }
 
   private _handleNewProposal = (e: any): void => {

--- a/src/components/Scheme/SchemeProposalsPage.tsx
+++ b/src/components/Scheme/SchemeProposalsPage.tsx
@@ -1,6 +1,6 @@
 import * as H from "history";
 import { Address, IDAOState, IProposalStage, ISchemeState, Proposal } from "@daostack/client";
-import { getArc, enableWalletProvider } from "arc";
+import { enableWalletProvider, getArc } from "arc";
 import Loading from "components/Shared/Loading";
 import withSubscription, { ISubscriptionProps } from "components/Shared/withSubscription";
 import { schemeName} from "lib/util";

--- a/src/components/Shared/PreTransactionModal.tsx
+++ b/src/components/Shared/PreTransactionModal.tsx
@@ -1,5 +1,5 @@
 import { IDAOState, IMemberState, IProposalState  } from "@daostack/client";
-import { enableWeb3ProviderAndWarn, loadCachedWeb3Provider } from "arc";
+import { enableWalletProvider } from "arc";
 
 import BN = require("bn.js");
 import * as classNames from "classnames";
@@ -63,8 +63,7 @@ class PreTransactionModal extends React.Component<IProps, IState> {
 
   public async handleClickAction() {
     const { actionType, showNotification } = this.props;
-    if (!await loadCachedWeb3Provider(showNotification) &&
-        !await enableWeb3ProviderAndWarn(showNotification)) { return; }
+    if (!await enableWalletProvider({ showNotification })) { return; }
 
     if (actionType === ActionTypes.StakeFail || actionType === ActionTypes.StakePass) {
       this.props.action(this.state.stakeAmount);

--- a/src/components/Shared/PreTransactionModal.tsx
+++ b/src/components/Shared/PreTransactionModal.tsx
@@ -1,5 +1,5 @@
 import { IDAOState, IMemberState, IProposalState  } from "@daostack/client";
-import { enableWeb3ProviderAndWarn } from "arc";
+import { enableWeb3ProviderAndWarn, loadCachedWeb3Provider } from "arc";
 
 import BN = require("bn.js");
 import * as classNames from "classnames";
@@ -62,8 +62,9 @@ class PreTransactionModal extends React.Component<IProps, IState> {
   }
 
   public async handleClickAction() {
-    const { actionType } = this.props;
-    if (!(await enableWeb3ProviderAndWarn(this.props.showNotification))) { return; }
+    const { actionType, showNotification } = this.props;
+    if (!await loadCachedWeb3Provider(showNotification) &&
+        !await enableWeb3ProviderAndWarn(showNotification)) { return; }
 
     if (actionType === ActionTypes.StakeFail || actionType === ActionTypes.StakePass) {
       this.props.action(this.state.stakeAmount);

--- a/src/layouts/Header.tsx
+++ b/src/layouts/Header.tsx
@@ -72,13 +72,13 @@ class Header extends React.Component<IProps, null> {
   }
 
   public handleClickLogin = async (_event: any): Promise<void> => {
-    if (!await loadCachedWeb3Provider(this.props.showNotification)) {
+    if (!await loadCachedWeb3Provider(this.props.showNotification, false)) {
       await enableWeb3ProviderAndWarn(this.props.showNotification, false);
     }
   }
 
   public handleConnect = async (_event: any): Promise<void> => {
-    if (!await loadCachedWeb3Provider(this.props.showNotification)) {
+    if (!await loadCachedWeb3Provider(this.props.showNotification, false)) {
       await enableWeb3ProviderAndWarn(this.props.showNotification, false);
     }
   }

--- a/src/layouts/Header.tsx
+++ b/src/layouts/Header.tsx
@@ -1,6 +1,6 @@
 import { Address, IDAOState } from "@daostack/client";
 import * as uiActions from "actions/uiActions";
-import { enableWeb3ProviderAndWarn, getAccountIsEnabled, getArc, gotoReadonly, IWeb3ProviderInfo, getWeb3ProviderInfo } from "arc";
+import { enableWeb3ProviderAndWarn, getAccountIsEnabled, getArc, gotoReadonly, getWeb3ProviderInfo, loadCachedWeb3Provider } from "arc";
 import * as classNames from "classnames";
 import AccountBalances from "components/Account/AccountBalances";
 import AccountImage from "components/Account/AccountImage";
@@ -22,8 +22,6 @@ import { of } from "rxjs";
 import * as css from "./App.scss";
 
 interface IExternalProps extends RouteComponentProps<any> {
-  loadCachedWeb3Provider: (showNotification: any) => Promise<boolean>;
-  getCachedWeb3ProviderInfo: () => IWeb3ProviderInfo | null;
 }
 
 interface IStateProps {
@@ -74,13 +72,13 @@ class Header extends React.Component<IProps, null> {
   }
 
   public handleClickLogin = async (_event: any): Promise<void> => {
-    if (!await this.props.loadCachedWeb3Provider(this.props.showNotification)) {
+    if (!await loadCachedWeb3Provider(this.props.showNotification)) {
       await enableWeb3ProviderAndWarn(this.props.showNotification, false);
     }
   }
 
   public handleConnect = async (_event: any): Promise<void> => {
-    if (!await this.props.loadCachedWeb3Provider(this.props.showNotification)) {
+    if (!await loadCachedWeb3Provider(this.props.showNotification)) {
       await enableWeb3ProviderAndWarn(this.props.showNotification, false);
     }
   }

--- a/src/layouts/Header.tsx
+++ b/src/layouts/Header.tsx
@@ -1,6 +1,6 @@
 import { Address, IDAOState } from "@daostack/client";
 import * as uiActions from "actions/uiActions";
-import { enableWeb3ProviderAndWarn, getAccountIsEnabled, getArc, gotoReadonly, getWeb3ProviderInfo, loadCachedWeb3Provider } from "arc";
+import { enableWalletProvider, getAccountIsEnabled, getArc, gotoReadonly, getWeb3ProviderInfo } from "arc";
 import * as classNames from "classnames";
 import AccountBalances from "components/Account/AccountBalances";
 import AccountImage from "components/Account/AccountImage";
@@ -72,15 +72,19 @@ class Header extends React.Component<IProps, null> {
   }
 
   public handleClickLogin = async (_event: any): Promise<void> => {
-    if (!await loadCachedWeb3Provider(this.props.showNotification, false)) {
-      await enableWeb3ProviderAndWarn(this.props.showNotification, false);
-    }
+    enableWalletProvider({
+      blockOnWrongNetwork: false,
+      notifyOnSuccess: false,
+      showNotification: this.props.showNotification,
+    });
   }
 
   public handleConnect = async (_event: any): Promise<void> => {
-    if (!await loadCachedWeb3Provider(this.props.showNotification, false)) {
-      await enableWeb3ProviderAndWarn(this.props.showNotification, false);
-    }
+    enableWalletProvider({
+      blockOnWrongNetwork: false,
+      notifyOnSuccess: false,
+      showNotification: this.props.showNotification,
+    });
   }
 
   public handleClickLogout = async (_event: any): Promise<void> => {


### PR DESCRIPTION
Resolves: https://daostack.tpondemand.com/RestUI/Board.aspx#page=board/5209716961861964288&appConfig=eyJhY2lkIjoiQjgzMTMzNDczNzlCMUI5QUE0RUE1NUVEOUQyQzdFNkIifQ==&boardPopup=bug/1648/silent

This completes the second part of the ticket:  "The logic should be the same regardless of how the user chooses to connect / login / make an action (e.g. stake when not connected)…  If we have a cached provider then use it, if no cached provider - show the web3connect dialogue…"

- calls to enableWeb3ProviderAndWarn now call enableWalletProvider instead
- unlike the old enableWeb3ProviderAndWarn, enableWalletProvider always looks to the cache first
- **Further note**  I am proposing here to issue a notification when the user is automatically connected (but not when doing it manually through the Connect or Log In buttons).