### PR TITLE
Compat design for DAO cards on mobile

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
     - Links in proposal description open in new tab
     - Show a message on startup when waiting for subgraph
     - Create a single place where all redemptions can be redeemed
+    - Nicer layout of the list of DAO cards on mobile devices
   - Bugs Fixed
     - Align headers of table in proposal history
     - Re-add redeem for beneficiary button to proposal details page

--- a/src/components/Daos/DaoCard.tsx
+++ b/src/components/Daos/DaoCard.tsx
@@ -49,15 +49,22 @@ const DaoCard = (props: IProps) => {
               Statistics
           </div>
 
-          <div className={css.daoInfo}>
-            <b>{daoState.memberCount || "0"}</b>
-            <span>Reputation Holders</span>
-          </div>
-
-          <div className={css.daoInfo}>
-            <b>{regularProposals.length + boostedProposals.length}</b>
-            <span>Open Proposals</span>
-          </div>
+          <table className={css.daoInfoContainer}>
+            <tr>
+              <td></td>
+              <td><div className={css.daoInfo}>
+                <b>{daoState.memberCount || "0"}</b>
+                <span>Reputation Holders</span>
+              </div>
+              </td>
+              <td><div className={css.daoInfo}>
+                <b>{regularProposals.length + boostedProposals.length}</b>
+                <span>Open Proposals</span>
+              </div>
+              </td>
+              <td></td>
+            </tr>
+          </table>
         </div>
       </div>
     </Link>

--- a/src/components/Daos/Daos.scss
+++ b/src/components/Daos/Daos.scss
@@ -144,7 +144,7 @@ a.daoLink {
 	}
 }
 
-@media only screen and (max-width: 425px) {
+@media only screen and (max-width: 550px) {
 	.wrapper {
 		width: auto;
 		padding: 0;
@@ -164,8 +164,8 @@ a.daoLink {
   }
 
   .daoList {
-    padding-left: 10px;
-    padding-right: 10px;
+    padding-left: 20px;
+    padding-right: 20px;
   }
 
 	.dao {

--- a/src/components/Daos/Daos.scss
+++ b/src/components/Daos/Daos.scss
@@ -93,7 +93,7 @@ a.daoLink {
 	.daoInfo {
 		color: $black;
 		font-size: $body;
-		width: 33%;
+		width: 100%;
 		display: inline-block;
 		padding: 30px 0;
 
@@ -144,6 +144,19 @@ a.daoLink {
 	}
 }
 
+table.daoInfoContainer {
+  width: 100%;
+  tr > td {
+    width:40%;
+    border: 0;
+    padding:0;
+  }
+  tr > td:first-child,
+  tr > td:last-child {
+    width:10%;
+  }
+}
+
 @media only screen and (max-width: 550px) {
 	.wrapper {
 		width: auto;
@@ -171,7 +184,7 @@ a.daoLink {
 	.dao {
 		width: 100%;
 		border-radius: 15px;
-		margin: 0 0 15px 0;
+		margin: 0 0 20px 0;
 		left: 0;
 	}
 
@@ -183,11 +196,30 @@ a.daoLink {
 		font-size: 20px;
 	}
 
-	.daoLink .daoInfo {
+	a.daoLink .daoInfo {
 		span {
 			font-size: 13px;
 			font-weight: normal;
 			font-family: "Open Sans";
 		}
 	}
+
+	a.daoLink .daoInfo {
+    padding: 18px 0;
+  }
+
+	a.daoLink .daoTitle {
+    padding-top: 16px;
+    padding-bottom:16px;
+		padding-left: 18px;
+		margin: 0;
+		margin-bottom: 10px;
+  }
+
+  table.daoInfoContainer {
+    tr > td:first-child,
+    tr > td:last-child {
+      width:10%;
+    }
+  }
 }

--- a/src/components/Daos/Daos.scss
+++ b/src/components/Daos/Daos.scss
@@ -217,6 +217,10 @@ table.daoInfoContainer {
   }
 
   table.daoInfoContainer {
+    tr > td {
+      width:45%;
+    }
+
     tr > td:first-child,
     tr > td:last-child {
       width:10%;


### PR DESCRIPTION
Resolves: https://daostack.tpondemand.com/RestUI/Board.aspx#page=board/5209716961861964288&appConfig=eyJhY2lkIjoiQjgzMTMzNDczNzlCMUI5QUE0RUE1NUVEOUQyQzdFNkIifQ==&boardPopup=userstory/1662/silent

Compat design for DAO cards on mobile.  "The biggest change is the vertical paddings and total height of a dao card (to have more DAOs show on one screen simultaneously)…"

I also cleaned up the layout of the statistics at certain page widths and fixed their fonts at mobile sizes, which weren't being set properly.