### PR TITLE
Feedback on whether there are unread Discus posts on DAO Wall

### DIFF
--- a/src/components/Dao/Dao.scss
+++ b/src/components/Dao/Dao.scss
@@ -15,7 +15,7 @@
   &.red {
     background-color: #f65050;
     border-radius: 50%;
-    bottom: 1px;
+    bottom: 2px;
     position: relative;
   }
 }

--- a/src/components/Dao/Dao.scss
+++ b/src/components/Dao/Dao.scss
@@ -11,6 +11,13 @@
   width: 8px;
   margin-left: 0;
   display: inline-block;
+
+  &.red {
+    background-color: #f65050;
+    border-radius: 50%;
+    bottom: 1px;
+    position: relative;
+  }
 }
 
 button:hover {

--- a/src/components/Dao/DaoDiscussionPage.tsx
+++ b/src/components/Dao/DaoDiscussionPage.tsx
@@ -5,11 +5,17 @@ import { BreadcrumbsItem } from "react-breadcrumbs-dynamic";
 import * as Sticky from "react-stickynode";
 import * as css from "./Dao.scss";
 
+import moment = require("moment");
+
 interface IProps {
   dao: IDAOState;
 }
 
 export default class DaoDiscussionPage extends React.Component<IProps, null> {
+
+  public async componentDidMount() {
+    localStorage.setItem(`daoWallEntryDate_${this.props.dao.address}`, moment().unix().toString());
+  }
 
   public render(): RenderOutput {
     const dao = this.props.dao;

--- a/src/components/Dao/DaoDiscussionPage.tsx
+++ b/src/components/Dao/DaoDiscussionPage.tsx
@@ -14,7 +14,7 @@ interface IProps {
 export default class DaoDiscussionPage extends React.Component<IProps, null> {
 
   public async componentDidMount() {
-    localStorage.setItem(`daoWallEntryDate_${this.props.dao.address}`, moment().unix().toString());
+    localStorage.setItem(`daoWallEntryDate_${this.props.dao.address}`, moment().toISOString());
   }
 
   public render(): RenderOutput {

--- a/src/components/Dao/DaoSidebar.tsx
+++ b/src/components/Dao/DaoSidebar.tsx
@@ -259,11 +259,7 @@ const SubscribedDaoSidebar = withSubscription({
   loadingComponent: <div className={css.loading}><Loading/></div>,
   createObservable: (props: IProps) => {
 
-    const lastAccessDate = localStorage.getItem(`daoWallEntryDate_${props.dao.address}`);
-
-    if (!lastAccessDate) {
-      return from(Promise.resolve({ hasNewPosts : false }));
-    }
+    const lastAccessDate = localStorage.getItem(`daoWallEntryDate_${props.dao.address}`) || "0";
 
     const promise = axios.get(`https://disqus.com/api/3.0/threads/listPosts.json?api_key=KVISHbDLtTycaGw5eoR8aQpBYN8bcVixONCXifYcih5CXanTLq0PpLh2cGPBkM4v&forum=${process.env.DISQUS_SITE}&thread:ident=${props.dao.address}&since=${lastAccessDate}&limit=1&order=asc`)
       .then((response: AxiosResponse<any>): IHasNewPosts => {

--- a/src/components/Dao/DaoSidebar.tsx
+++ b/src/components/Dao/DaoSidebar.tsx
@@ -265,7 +265,7 @@ const SubscribedDaoSidebar = withSubscription({
       return from(Promise.resolve({ hasNewPosts : false }));
     }
 
-    const promise = axios.get(`https://disqus.com/api/3.0/threads/listPosts.json?api_key=KVISHbDLtTycaGw5eoR8aQpBYN8bcVixONCXifYcih5CXanTLq0PpLh2cGPBkM4v&forum=${process.env.DISQUS_SITE}&thread:ident=${props.dao.address}&since=${lastAccessDate}&limit=1`)
+    const promise = axios.get(`https://disqus.com/api/3.0/threads/listPosts.json?api_key=KVISHbDLtTycaGw5eoR8aQpBYN8bcVixONCXifYcih5CXanTLq0PpLh2cGPBkM4v&forum=${process.env.DISQUS_SITE}&thread:ident=${props.dao.address}&since=${lastAccessDate}&limit=1&order=asc`)
       .then((response: AxiosResponse<any>): IHasNewPosts => {
         if (response.status) {
           const posts = response.data.response;

--- a/src/components/Dao/DaoSidebar.tsx
+++ b/src/components/Dao/DaoSidebar.tsx
@@ -261,7 +261,7 @@ const SubscribedDaoSidebar = withSubscription({
 
     const lastAccessDate = localStorage.getItem(`daoWallEntryDate_${props.dao.address}`) || "0";
 
-    const promise = axios.get(`https://disqus.com/api/3.0/threads/listPosts.json?api_key=KVISHbDLtTycaGw5eoR8aQpBYN8bcVixONCXifYcih5CXanTLq0PpLh2cGPBkM4v&forum=${process.env.DISQUS_SITE}&thread:ident=${props.dao.address}&since=${lastAccessDate}&limit=1&order=asc`)
+    const promise = axios.get(`https://disqus.com/api/3.0/threads/listPosts.json?api_key=KVISHbDLtTycaGw5eoR8aQpBYN8bcVixONCXifYcih5CXanTLq0PpLh2cGPBkM4v&forum=${process.env.DISQUS_SITE}&thread:ident=${props.dao.address}&since=${lastAccessDate}&limit=1&order=desc`)
       .then((response: AxiosResponse<any>): IHasNewPosts => {
         if (response.status) {
           const posts = response.data.response;

--- a/src/components/Dao/DaoSidebar.tsx
+++ b/src/components/Dao/DaoSidebar.tsx
@@ -15,8 +15,6 @@ import { IRootState } from "reducers";
 import { connect } from "react-redux";
 import * as css from "./Dao.scss";
 
-import moment = require("moment");
-
 interface IExternalProps {
   dao: IDAOState;
 }
@@ -261,7 +259,11 @@ const SubscribedDaoSidebar = withSubscription({
   loadingComponent: <div className={css.loading}><Loading/></div>,
   createObservable: (props: IProps) => {
 
-    const lastAccessDate = moment("2019-10-02T07:06:40+00:00").unix();
+    const lastAccessDate = localStorage.getItem(`daoWallEntryDate_${props.dao.address}`);
+
+    if (!lastAccessDate) {
+      return from(Promise.resolve({ hasNewPosts : false }));
+    }
 
     const promise = axios.get(`https://disqus.com/api/3.0/threads/listPosts.json?api_key=KVISHbDLtTycaGw5eoR8aQpBYN8bcVixONCXifYcih5CXanTLq0PpLh2cGPBkM4v&forum=${process.env.DISQUS_SITE}&thread:ident=${props.dao.address}&since=${lastAccessDate}&limit=1`)
       .then((response: AxiosResponse<any>): IHasNewPosts => {

--- a/src/components/Dao/DaoSidebar.tsx
+++ b/src/components/Dao/DaoSidebar.tsx
@@ -261,7 +261,7 @@ const SubscribedDaoSidebar = withSubscription({
 
     const lastAccessDate = localStorage.getItem(`daoWallEntryDate_${props.dao.address}`) || "0";
 
-    const promise = axios.get(`https://disqus.com/api/3.0/threads/listPosts.json?api_key=KVISHbDLtTycaGw5eoR8aQpBYN8bcVixONCXifYcih5CXanTLq0PpLh2cGPBkM4v&forum=${process.env.DISQUS_SITE}&thread:ident=${props.dao.address}&since=${lastAccessDate}&limit=1&order=desc`)
+    const promise = axios.get(`https://disqus.com/api/3.0/threads/listPosts.json?api_key=KVISHbDLtTycaGw5eoR8aQpBYN8bcVixONCXifYcih5CXanTLq0PpLh2cGPBkM4v&forum=${process.env.DISQUS_SITE}&thread:ident=${props.dao.address}&since=${lastAccessDate}&limit=1&order=asc`)
       .then((response: AxiosResponse<any>): IHasNewPosts => {
         if (response.status) {
           const posts = response.data.response;


### PR DESCRIPTION
Resolves: https://daostack.tpondemand.com/RestUI/Board.aspx#page=board/5209716961861964288&appConfig=eyJhY2lkIjoiQjgzMTMzNDczNzlCMUI5QUE0RUE1NUVEOUQyQzdFNkIifQ==&boardPopup=userstory/1649/silent

Show red dot next to "DAO Wall" in sidebar when there are unread messages.

**Important**:  To use the Disqus API I had to create an "[API Application](https://help.disqus.com/en/articles/1717083-how-to-create-an-api-application)" in Disqus.  I have enabled access to any domain for debugging until this PR is merged.  Access is limited to "readonly" in any case.

**Note** API access is throttled without upgrading to a "Pro" subscription, which we already have.  Yet it is reporting that we have a limit of 1000 queries per hour.

Here is the API Application config:  https://disqus.com/api/applications/6076435/