### PR TITLE
Display Redeemable REP On-Hover

### DIFF
--- a/src/components/Account/Reputation.tsx
+++ b/src/components/Account/Reputation.tsx
@@ -45,10 +45,24 @@ export default class Reputation extends React.Component<IProps, null> {
       }
     }
 
+    const totalRepFormatted = fromWei(totalReputation).toLocaleString(
+      undefined, {minimumFractionDigits: 0, maximumFractionDigits: 2}
+    );
+
+    const repFormatted = fromWei(reputation).toLocaleString(
+      undefined, {minimumFractionDigits: 0, maximumFractionDigits: 2}
+    );
+
     return (
       <Tooltip
         placement="bottom"
-        overlay={<span>{fromWei(totalReputation).toLocaleString(undefined, {minimumFractionDigits: 0, maximumFractionDigits: 2})} {daoName || ""} Reputation in total</span>}
+        overlay={
+          <>
+          <span>{repFormatted} Rep.</span>
+          <br/>
+          <span>{totalRepFormatted} {daoName || ""} Reputation in total</span>
+          </>
+        }
         trigger={hideTooltip ? [] : ["hover"]}
       >
         <span data-test-id="reputation">


### PR DESCRIPTION
For dOrg, having the amount the agent is requested readily available is needed for us to properly audit payments. Currently Alchemy only shows the percentage and the total REP in the DAO.

Closes https://github.com/daostack/alchemy/issues/979