### PR TITLE
WIP: clean up visible DAO card resorting on DAOs page

### DIFF
--- a/src/components/Daos/DaoCard.tsx
+++ b/src/components/Daos/DaoCard.tsx
@@ -14,7 +14,7 @@ export type IObservableProps = [Proposal[], Proposal[], IDAOState];
 
 interface IExternalProps {
   /**
-   * The promised results from `DaoCard.getObservable`
+   * The promised results from `DaoCard.createObservable`
    */
   data?: IObservableProps;
 }
@@ -94,18 +94,3 @@ export default class DaoCard extends React.Component<IProps, null> {
     );
   }
 }
-
-// export default withSubscription({
-//   wrappedComponent: DaoCard,
-//   loadingComponent: null,
-//   errorComponent: (props) => <div>{ props.error.message }</div>,
-
-//   checkForUpdate: (oldProps, newProps) => {
-//     // TODO: does dao.id work here or do we need to load the static state?
-//     return oldProps.dao.id !== newProps.dao.id;
-//   },
-
-//   createObservable: (props: IExternalProps) => {
-//     return props.observable;
-//   },
-// });

--- a/src/components/Daos/DaoCard.tsx
+++ b/src/components/Daos/DaoCard.tsx
@@ -3,89 +3,27 @@ import { DAO, IDAOState,
   Proposal,
 } from "@daostack/client";
 import classNames from "classnames";
-import withSubscription, { ISubscriptionProps } from "components/Shared/withSubscription";
 import * as GeoPattern from "geopattern";
 import * as moment from "moment";
 import * as React from "react";
 import { Link } from "react-router-dom";
-import { combineLatest } from "rxjs";
+import { combineLatest, Observable } from "rxjs";
 import * as css from "./Daos.scss";
 
+export type IObservableProps = [Proposal[], Proposal[], IDAOState];
+
 interface IExternalProps {
-  dao: DAO;
+  /**
+   * The promised results from `DaoCard.getObservable`
+   */
+  data?: IObservableProps;
 }
 
-type IProps = IExternalProps & ISubscriptionProps<[Proposal[], Proposal[], IDAOState]>
+type IProps = IExternalProps;
 
-const DaoCard = (props: IProps) => {
-  const { dao } = props;
-  const [regularProposals, boostedProposals, daoState] = props.data;
-  const bgPattern = GeoPattern.generate(dao.id + daoState.name);
-  const dxDaoActivationDate = moment("2019-07-14T12:00:00.000+0000");
-  const inActive = (daoState.name === "dxDAO") && dxDaoActivationDate.isSameOrAfter(moment());
+export default class DaoCard extends React.Component<IProps, null> {
 
-  return (
-    <Link
-      className={css.daoLink}
-      to={"/dao/" + dao.id}
-      key={"dao_" + dao.id}
-      data-test-id="dao-link"
-      onClick={(e) => { if (inActive) { e.preventDefault(); } }}
-    >
-      <div className={classNames({
-        [css.dao]: true,
-        [css.daoInactive]: inActive})}>
-        <div className={css.daoTitle}
-          style={{backgroundImage: bgPattern.toDataUrl()}}>
-
-          <div className={css.daoName}>{daoState.name}</div>
-
-          {inActive ? <div className={css.inactiveFeedback} ><div className={css.time}>{ dxDaoActivationDate.format("MMM Do")}&nbsp;
-            {dxDaoActivationDate.format("h:mma z")}</div><img src="/assets/images/Icon/alarm.svg"></img></div> : ""}
-        </div>
-
-        <div className={"clearfix " + css.daoInfoContainer}>
-          <div className={css.daoInfoTitle}>
-              Statistics
-          </div>
-
-          <table className={css.daoInfoContainer}>
-            <tbody>
-              <tr>
-                <td></td>
-                <td><div className={css.daoInfo}>
-                  <b>{daoState.memberCount || "0"}</b>
-                  <span>Reputation Holders</span>
-                </div>
-                </td>
-                <td><div className={css.daoInfo}>
-                  <b>{regularProposals.length + boostedProposals.length}</b>
-                  <span>Open Proposals</span>
-                </div>
-                </td>
-                <td></td>
-              </tr>
-            </tbody>
-          </table>
-        </div>
-      </div>
-    </Link>
-  );
-};
-
-export default withSubscription({
-  wrappedComponent: DaoCard,
-  loadingComponent: null,
-  errorComponent: (props) => <div>{ props.error.message }</div>,
-
-  checkForUpdate: (oldProps, newProps) => {
-    // TODO: does dao.id work here or do we need to load the static state?
-    return oldProps.dao.id !== newProps.dao.id;
-  },
-
-  createObservable: (props: IExternalProps) => {
-    const dao = props.dao;
-
+  public static createObservable(dao: DAO): Observable<IObservableProps> {
     return combineLatest(
       dao.proposals({ where: {
         // eslint-disable-next-line @typescript-eslint/camelcase
@@ -99,5 +37,75 @@ export default withSubscription({
       }}),
       dao.state() // subscriptions taken care of by parent compnent
     );
-  },
-});
+  }
+
+  public render(): RenderOutput {
+    const [regularProposals, boostedProposals, daoState] = this.props.data;
+    const bgPattern = GeoPattern.generate(daoState.id + daoState.name);
+    const dxDaoActivationDate = moment("2019-07-14T12:00:00.000+0000");
+    const inActive = (daoState.name === "dxDAO") && dxDaoActivationDate.isSameOrAfter(moment());
+
+    return (
+      <Link
+        className={css.daoLink}
+        to={"/dao/" + daoState.id}
+        key={"dao_" + daoState.id}
+        data-test-id="dao-link"
+        onClick={(e) => { if (inActive) { e.preventDefault(); } }}
+      >
+        <div className={classNames({
+          [css.dao]: true,
+          [css.daoInactive]: inActive})}>
+          <div className={css.daoTitle}
+            style={{backgroundImage: bgPattern.toDataUrl()}}>
+
+            <div className={css.daoName}>{daoState.name}</div>
+
+            {inActive ? <div className={css.inactiveFeedback} ><div className={css.time}>{ dxDaoActivationDate.format("MMM Do")}&nbsp;
+              {dxDaoActivationDate.format("h:mma z")}</div><img src="/assets/images/Icon/alarm.svg"></img></div> : ""}
+          </div>
+
+          <div className={"clearfix " + css.daoInfoContainer}>
+            <div className={css.daoInfoTitle}>
+              Statistics
+            </div>
+
+            <table className={css.daoInfoContainer}>
+              <tbody>
+                <tr>
+                  <td></td>
+                  <td><div className={css.daoInfo}>
+                    <b>{daoState.memberCount || "0"}</b>
+                    <span>Reputation Holders</span>
+                  </div>
+                  </td>
+                  <td><div className={css.daoInfo}>
+                    <b>{regularProposals.length + boostedProposals.length}</b>
+                    <span>Open Proposals</span>
+                  </div>
+                  </td>
+                  <td></td>
+                </tr>
+              </tbody>
+            </table>
+          </div>
+        </div>
+      </Link>
+    );
+  }
+}
+
+// export default withSubscription({
+//   wrappedComponent: DaoCard,
+//   loadingComponent: null,
+//   errorComponent: (props) => <div>{ props.error.message }</div>,
+
+//   checkForUpdate: (oldProps, newProps) => {
+//     // TODO: does dao.id work here or do we need to load the static state?
+//     return oldProps.dao.id !== newProps.dao.id;
+//   },
+
+//   createObservable: (props: IExternalProps) => {
+//     return props.observable;
+//   },
+// });

--- a/src/components/Daos/DaosPage.tsx
+++ b/src/components/Daos/DaosPage.tsx
@@ -4,26 +4,26 @@ import Loading from "components/Shared/Loading";
 import withSubscription, { ISubscriptionProps } from "components/Shared/withSubscription";
 import * as React from "react";
 import * as Sticky from "react-stickynode";
-import { combineLatest} from "rxjs";
-import DaoCard from "./DaoCard";
+import { mergeMap } from "rxjs/operators";
+import { Observable, combineLatest } from "rxjs";
+import DaoCard, { IObservableProps } from "./DaoCard";
 import * as css from "./Daos.scss";
 
-type SubscriptionData = [DAO[], DAO[]];
-
-type IProps = ISubscriptionProps<SubscriptionData>;
+type IProps = ISubscriptionProps<[IObservableProps[], IObservableProps[]]>;
 
 class DaosPage extends React.Component<IProps, null> {
 
   public render(): RenderOutput {
     const { data } = this.props;
 
-    const daos = [...data[0], ...data[1]];
+    const daoInfos = [...data[0], ...data[1]];
 
-    const daoNodes = daos.map((dao: DAO) => {
+    const daoNodes = daoInfos.map((daoInfo: IObservableProps) => {
       return (
-        <DaoCard key={dao.id}  dao={dao}/>
+        <DaoCard key={daoInfo[2].id} data={daoInfo}/>
       );
     });
+
     return (
       <div className={css.wrapper}>
         <Sticky enabled top={50} innerZ={10000}>
@@ -48,12 +48,30 @@ export default withSubscription({
   checkForUpdate: () => { return false; },
 
   createObservable: () => {
+
     const arc = getArc();
+
+    const toDaoCardObservables = (daos: DAO[]): Observable<IObservableProps[]> => {
+
+      const cardObservables: Observable<IObservableProps>[] = [];
+
+      daos.map((dao: DAO): void => {
+        cardObservables.push(DaoCard.createObservable(dao));
+      });
+
+      return combineLatest(...cardObservables);
+    };
+
+    /**
+     * So we don't start to render until all the DAO information has been fetched, otherwise each DAO will be
+     * fetched independently, each in its own time, and thus we'll see them appearing initially in wrong sequences.
+     */
     return combineLatest(
-      arc.daos({ where: { name: "Genesis Alpha" }}, { fetchAllData: true, subscribe: true }),
-      // eslint-disable-next-line
-      arc.daos({ where: { name_not_contains: "Genesis Alpha", register: "registered" },
-        orderBy: "name", orderDirection: "asc"}, { fetchAllData: true, subscribe: true }),
+      arc.daos({ where: { name: "Genesis Alpha" }}, { fetchAllData: true, subscribe: true })
+        .pipe(mergeMap(toDaoCardObservables)),
+      // eslint-disable-next-line @typescript-eslint/camelcase
+      arc.daos({ where: { name_not_contains: "Genesis Alpha", register: "registered" }, orderBy: "name", orderDirection: "asc"}, { fetchAllData: true, subscribe: true })
+        .pipe(mergeMap(toDaoCardObservables)),
     );
   },
 });


### PR DESCRIPTION
Resolves: https://daostack.tpondemand.com/RestUI/Board.aspx#page=board/5209716961861964288&appConfig=eyJhY2lkIjoiQjgzMTMzNDczNzlCMUI5QUE0RUE1NUVEOUQyQzdFNkIifQ==&boardPopup=bug/1713/silent

This addresses issue of visible DAO list resorting by preloading the DaoCard data.

Current caveats:

* I haven't confirmed that with this method the Dao cards refresh when the DAO data changes.
* There is a bit of a glitch in positioning the busy spinny icon
* There are merge conflicts with dev
* Maybe this won't be needed, depending on Jelle's ["less subscriptions" PR](https://github.com/daostack/alchemy/pull/1147)