### PR TITLE
equalize button text font sizes

### DIFF
--- a/src/components/Proposal/Staking/StakeButtons.scss
+++ b/src/components/Proposal/Staking/StakeButtons.scss
@@ -34,6 +34,7 @@
     line-height: 14px;
     position: relative;
     border: 0;
+    margin: 0 1px;
     display: inline-block;
     width: 60px;
     top: 0;

--- a/src/components/Proposal/Staking/StakeButtons.scss
+++ b/src/components/Proposal/Staking/StakeButtons.scss
@@ -34,10 +34,10 @@
     line-height: 14px;
     position: relative;
     border: 0;
-    margin: 0 1px;
     display: inline-block;
     width: 60px;
     top: 0;
+    outline: none;
 
     strong {
       opacity: 1;
@@ -146,7 +146,6 @@
 
 .failButton {
   border-radius: 0 10px 10px 0;
-  top: 1px !important;
 }
 
 .predictions.unconfirmedPrediction {
@@ -170,7 +169,6 @@
     height: auto;
     padding-left: 5px;
     padding-right: 6px;
-    font-size: 11px;
     line-height: initial;
     padding-top: 5px;
     padding-bottom: 7px;
@@ -358,7 +356,6 @@
     padding: 5px 0;
     border-radius: 0;
     margin: 0 0 0 0;
-    font-size: 11px;
     color: rgba(78, 97, 118, 1.000);
     font-weight: normal;
 

--- a/src/components/Proposal/Voting/VoteButtons.scss
+++ b/src/components/Proposal/Voting/VoteButtons.scss
@@ -197,7 +197,6 @@ button.disabled {
   display: inline-block;
   width: 75px;
   padding: 0 5px;
-  font-size: 11px;
   outline: none;
 
   img {

--- a/src/components/Proposal/Voting/VoteButtons.scss
+++ b/src/components/Proposal/Voting/VoteButtons.scss
@@ -193,7 +193,7 @@ button.disabled {
   transition: all .25s ease;
   position: relative;
   border: 0;
-  margin: 0 1px;
+  margin: 0;
   display: inline-block;
   width: 75px;
   padding: 0 5px;

--- a/src/components/Proposal/Voting/VoteButtons.scss
+++ b/src/components/Proposal/Voting/VoteButtons.scss
@@ -193,7 +193,7 @@ button.disabled {
   transition: all .25s ease;
   position: relative;
   border: 0;
-  margin: 0;
+  margin: 0 1px;
   display: inline-block;
   width: 75px;
   padding: 0 5px;


### PR DESCRIPTION
Resolves: https://daostack.tpondemand.com/RestUI/Board.aspx#page=board/4789434231796866533&appConfig=eyJhY2lkIjoiMEFGRDcyNjIyOTgzRjFFMkMwRjIwMDBCNzA0QjRGMzQifQ==&boardPopup=bug/1483/silent

Resolves: https://daostack.tpondemand.com/RestUI/Board.aspx#page=board/5209716961861964288&appConfig=eyJhY2lkIjoiQjgzMTMzNDczNzlCMUI5QUE0RUE1NUVEOUQyQzdFNkIifQ==&boardPopup=bug/1658/silent

After much going back and forth, I decided not to remove the gaps in the staking and voting buttons.  I feel that the gap makes it easier to know these are two buttons.  And I have run across precendent for this design elsewhere on the web.

But again finding that the font sizes are different in voting versus staking buttons, I made them the same, opting to choose the larger size in each case (the topic of [this ticket](https://daostack.tpondemand.com/RestUI/Board.aspx#page=board/4789434231796866533&appConfig=eyJhY2lkIjoiMEFGRDcyNjIyOTgzRjFFMkMwRjIwMDBCNzA0QjRGMzQifQ==&boardPopup=bug/1483/silent)).

As follows:

![image](https://user-images.githubusercontent.com/1821666/66674847-f9340780-ec31-11e9-9596-98d6668f1f3f.png)
![image](https://user-images.githubusercontent.com/1821666/66696854-97a98280-ec9d-11e9-9100-f8dc991d0b12.png)
![image](https://user-images.githubusercontent.com/1821666/66696859-a001bd80-ec9d-11e9-91ed-416281b0b079.png)


