### PR TITLE
show notifs on Enable Predictions

### DIFF
--- a/src/actions/arcActions.ts
+++ b/src/actions/arcActions.ts
@@ -111,6 +111,15 @@ export function stakeProposal(daoAvatarAddress: string, proposalId: string, pred
   };
 }
 
+// Approve transfer of 100000 GENs from accountAddress to the GenesisProtocol contract for use in staking
+export function approveStakingGens(spender: Address) {
+  return async (dispatch: Redux.Dispatch<any, any>, ) => {
+    const arc = getArc();
+    const observer = operationNotifierObserver(dispatch, "Approve GEN");
+    await arc.approveForStaking(spender, toWei(100000)).subscribe(...observer);
+  };
+}
+
 export type RedeemAction = IAsyncAction<"ARC_REDEEM", {
   avatarAddress: string;
   proposalId: string;

--- a/src/actions/web3Actions.ts
+++ b/src/actions/web3Actions.ts
@@ -1,12 +1,8 @@
-import { Address } from "@daostack/client";
 import * as Sentry from "@sentry/browser";
 import { getProfile } from "actions/profilesActions";
-import { getArc } from "arc";
-import { toWei } from "lib/util";
-import { IRootState } from "reducers";
-import { ActionTypes, ConnectionStatus, IWeb3State } from "reducers/web3Reducer";
+import { ActionTypes, IWeb3State } from "reducers/web3Reducer";
 import * as Redux from "redux";
-import { AsyncActionSequence, IAsyncAction } from "./async";
+import { IAsyncAction } from "./async";
 
 export type ConnectAction = IAsyncAction<"WEB3_CONNECT", void, IWeb3State>;
 
@@ -14,7 +10,6 @@ export function setCurrentAccount(accountAddress: string) {
   return async (dispatch: Redux.Dispatch<any, any>, _getState: Function) => {
     const payload = {
       currentAccountAddress: accountAddress,
-      connectionStatus : ConnectionStatus.Connected,
     };
 
     const action = {
@@ -35,46 +30,5 @@ export function setCurrentAccount(accountAddress: string) {
     }
 
     dispatch(getProfile(accountAddress));
-  };
-}
-
-export type ApproveAction = IAsyncAction<ActionTypes.APPROVE_STAKING_GENS, {
-  accountAddress: string;
-}, {
-  numTokensApproved: number;
-}>;
-
-// Approve transfer of 100000 GENs from accountAddress to the GenesisProtocol contract for use in staking
-export function approveStakingGens(spender: Address) {
-  return async (dispatch: Redux.Dispatch<any, any>, getState: () => IRootState) => {
-    const arc = getArc();
-    const currentAccountAddress: string = getState().web3.currentAccountAddress;
-
-    const meta = { accountAddress: currentAccountAddress };
-
-    dispatch({
-      type: ActionTypes.APPROVE_STAKING_GENS,
-      sequence: AsyncActionSequence.Pending,
-      operation: {
-        message: "Approving tokens for staking...",
-        totalSteps: 1,
-      },
-      meta,
-    } as ApproveAction);
-
-    try {
-      await arc.approveForStaking(spender, toWei(100000)).send();
-    } catch (err) {
-      // eslint-disable-next-line no-console
-      console.error(err);
-      dispatch({
-        type: ActionTypes.APPROVE_STAKING_GENS,
-        sequence: AsyncActionSequence.Failure,
-        meta,
-        operation: {
-          message: "Approving tokens for staking failed",
-        },
-      } as ApproveAction);
-    }
   };
 }

--- a/src/components/Proposal/Staking/StakeButtons.tsx
+++ b/src/components/Proposal/Staking/StakeButtons.tsx
@@ -1,6 +1,5 @@
 import { Address, IDAOState, IProposalStage, IProposalState, Stake } from "@daostack/client";
 import * as arcActions from "actions/arcActions";
-import * as web3Actions from "actions/web3Actions";
 import { enableWalletProvider } from "arc";
 
 import BN = require("bn.js");
@@ -40,11 +39,11 @@ interface IExternalProps {
 interface IDispatchProps {
   stakeProposal: typeof arcActions.stakeProposal;
   showNotification: typeof showNotification;
-  approveStakingGens: typeof web3Actions.approveStakingGens;
+  approveStakingGens: typeof arcActions.approveStakingGens;
 }
 
 const mapDispatchToProps = {
-  approveStakingGens: web3Actions.approveStakingGens,
+  approveStakingGens: arcActions.approveStakingGens,
   stakeProposal: arcActions.stakeProposal,
   showNotification,
 };

--- a/src/layouts/AppContainer.tsx
+++ b/src/layouts/AppContainer.tsx
@@ -118,7 +118,6 @@ class AppContainer extends React.Component<IProps, IState> {
 
   public render(): RenderOutput {
     const {
-      // connectionStatus,
       dismissNotification,
       showNotification,
       sortedNotifications,

--- a/src/reducers/web3Reducer.ts
+++ b/src/reducers/web3Reducer.ts
@@ -1,26 +1,16 @@
 export enum ActionTypes {
-  WEB3_CONNECT = "WEB3_CONNECT",
   WEB3_SET_ACCOUNT = "WEB3_SET_ACCOUNT",
-  APPROVE_STAKING_GENS = "APPROVE_STAKING_GENS",
   OTHER_ACTION = "__any_other_action_type__",
-}
-
-export enum ConnectionStatus {
-  Pending = "pending",
-  Connected = "connected",
-  Failed = "failed",
 }
 
 export interface IWeb3State {
   accounts: string[];
-  connectionStatus: ConnectionStatus;
   currentAccountAddress: string | null;
   networkId: number;
 }
 
 const initialState: IWeb3State = {
   accounts: [],
-  connectionStatus: ConnectionStatus.Pending,
   currentAccountAddress: null,
   networkId: 0, // unknown network
 };
@@ -30,10 +20,6 @@ const web3Reducer = (state = initialState, action: any) => {
 
     case ActionTypes.WEB3_SET_ACCOUNT:
       return {...state, ...action.payload };
-
-    case ActionTypes.APPROVE_STAKING_GENS: {
-      return state;
-    }
 
     default: {
       return state;


### PR DESCRIPTION
Resolves: https://daostack.tpondemand.com/RestUI/Board.aspx#page=board/5209716961861964288&appConfig=eyJhY2lkIjoiQjgzMTMzNDczNzlCMUI5QUE0RUE1NUVEOUQyQzdFNkIifQ==&boardPopup=bug/1546/silent

Resolves: https://github.com/daostack/alchemy/issues/1073

* Transaction notifications are now shown when enabling predictions, just like other txs.
* Removed some unused code
