### PR TITLE
display quiet ending status

### DIFF
--- a/src/components/Proposal/ProposalStatus.scss
+++ b/src/components/Proposal/ProposalStatus.scss
@@ -3,7 +3,7 @@
   display: inline-block;
 }
 
-.boosted, .passed {
+.quietEnding, .boosted, .passed {
   color: $accent-3;
 }
 

--- a/src/components/Proposal/ProposalStatus.tsx
+++ b/src/components/Proposal/ProposalStatus.tsx
@@ -62,10 +62,16 @@ export default class ProposalStatus extends React.Component<IProps, null> {
                         [css.boosted]: true,
                       })}><img src="/assets/images/Icon/boosted.svg" />Boosted</div> :
 
-                      <div className={classNames({
-                        [css.status]: true,
-                        [css.expired]: true,
-                      })}>[unknown status]</div>
+                      (proposalState.stage === IProposalStage.QuietEndingPeriod) ?
+                        <div className={classNames({
+                          [css.status]: true,
+                          [css.quietEnding]: true,
+                        })}><img src="/assets/images/Icon/boosted.svg" />Quiet Ending</div> :
+
+                        <div className={classNames({
+                          [css.status]: true,
+                          [css.expired]: true,
+                        })}>[unknown status]</div>
         )
         }
       </div>


### PR DESCRIPTION
Resolves: https://daostack.tpondemand.com/RestUI/Board.aspx#page=board/5209716961861964288&appConfig=eyJhY2lkIjoiQjgzMTMzNDczNzlCMUI5QUE0RUE1NUVEOUQyQzdFNkIifQ==&boardPopup=bug/1731/silent

Looks like Boosted, but displays "Quiet Ending"