### PR TITLE
nervous account menu: drop down instead of left

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@
     - Fix error on initializing arc
     - Fix infinite scroll loading of queued scheme proposals
     - handle Metamask account changing
+    - fix "nervous" account menu, now drops down instead of across
 
 ### 2019-09-12 [actually two releases]
 

--- a/src/layouts/App.scss
+++ b/src/layouts/App.scss
@@ -202,16 +202,18 @@ body {
 
     .wallet {
       position: absolute;
-      top: 43px;
-      width: 0px;
-      opacity: 0;
-      transition: all .25s ease;
+      width: 270px;
+      top: 50px;
+      transform: scaleY(0);    
+      transform-origin: top;
+      transition: transform 0.25s ease;
       right: 12px;
       font-size: 12px;
       z-index: 100;
       color: rgba(78, 97, 118, 1.000);
       background-color: rgba(252, 253, 255, 1.000);
       border-radius: 0 0 8px 8px;
+      box-shadow: 0 2px 16px 0 rgba(133, 168, 208, 0.27);
 
       .walletImage {
         float: left;
@@ -434,11 +436,13 @@ body {
   .accountInfoContainer:hover{
     background-color: rgba(10, 28, 61, 1.000);
 
-    .wallet {
-      width: 270px;
-      opacity: 1;
-      box-shadow: 0 2px 16px 0 rgba(133, 168, 208, 0.27);
+    + .wallet {
+    transform: scaleY(1);
     }
+  }
+
+  .wallet:hover {
+    transform: scaleY(1);
   }
 
   .etherBalance {

--- a/src/layouts/Header.tsx
+++ b/src/layouts/Header.tsx
@@ -136,14 +136,16 @@ class Header extends React.Component<IProps, IStateProps> {
           </div>
           <div className={css.accountInfo}>
             { currentAccountAddress ?
-              <div className={css.accountInfoContainer}>
-                <div className={css.accountImage}>
-                  <div className={classNames({ [css.profileLink]: true, [css.noAccount]: !accountIsEnabled })}>
-                    <AccountProfileName accountAddress={currentAccountAddress}
-                      accountProfile={currentAccountProfile} daoAvatarAddress={daoAvatarAddress} />
-                    <span className={classNames({ [css.walletImage]: true, [css.greyscale]: !accountIsEnabled })}>
-                      <AccountImage accountAddress={currentAccountAddress} />
-                    </span>
+              <span>
+                <div className={css.accountInfoContainer}>
+                  <div className={css.accountImage}>
+                    <div className={classNames({ [css.profileLink]: true, [css.noAccount]: !accountIsEnabled })}>
+                      <AccountProfileName accountAddress={currentAccountAddress}
+                        accountProfile={currentAccountProfile} daoAvatarAddress={daoAvatarAddress} />
+                      <span className={classNames({ [css.walletImage]: true, [css.greyscale]: !accountIsEnabled })}>
+                        <AccountImage accountAddress={currentAccountAddress} />
+                      </span>
+                    </div>
                   </div>
                 </div>
                 <div className={css.wallet}>
@@ -179,7 +181,7 @@ class Header extends React.Component<IProps, IStateProps> {
                       <div className={css.web3ProviderLogInOut}  onClick={this.handleConnect}><div className={css.text}>Connect</div> <img src="/assets/images/Icon/login.svg"/></div> }
                   </div>
                 </div>
-              </div> : ""
+              </span> : ""
             }
             {!currentAccountAddress ?
               <div className={css.web3ProviderLogin}>


### PR DESCRIPTION
Resolves: https://daostack.tpondemand.com/RestUI/Board.aspx#page=board/5209716961861964288&appConfig=eyJhY2lkIjoiQjgzMTMzNDczNzlCMUI5QUE0RUE1NUVEOUQyQzdFNkIifQ==&boardPopup=bug/1748/silent

Solution is to drop the menu down rather than from the side.  I think this is better UX anyway, since the trigger for the menu is at the top, not on the right.