### PR TITLE
Block redeem when can't be paid

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@
 ### Current
 
   - Features Added
-    -
+    - prevent attempting redemptions unless there exist sufficient resources to pay out at least one reward
   - Bugs Fixed
     -
 

--- a/src/assets/styles/_rc-tooltip.scss
+++ b/src/assets/styles/_rc-tooltip.scss
@@ -111,7 +111,7 @@
   font-size: 12px;
   background-color: $white;
   padding: 1px;
-  opacity: 0.9;
+  opacity: 1;
 }
 .rc-tooltip-hidden {
   display: none;

--- a/src/components/Proposal/ActionButton.tsx
+++ b/src/components/Proposal/ActionButton.tsx
@@ -189,6 +189,7 @@ class ActionButton extends React.Component<IProps, IState> {
             dao={daoState}
             effectText={redemptionsTip}
             proposal={proposalState}
+            multiLineMsg
           /> : ""
         }
 

--- a/src/components/Proposal/ActionButton.tsx
+++ b/src/components/Proposal/ActionButton.tsx
@@ -25,7 +25,7 @@ interface IExternalProps {
   expanded?: boolean;
   proposalState: IProposalState;
   /**
-   * unredeemed GP rewards due to the current account
+   * unredeemed GP rewards owed to the current account
    */
   rewards: IRewardState;
   expired: boolean;
@@ -102,7 +102,7 @@ class ActionButton extends React.Component<IProps, IState> {
       expanded,
       proposalState,
       /**
-       * unredeemed GP rewards due to the current account
+       * unredeemed GP rewards owed to the current account
        */
       rewards,
     } = this.props;

--- a/src/components/Proposal/ActionButton.tsx
+++ b/src/components/Proposal/ActionButton.tsx
@@ -29,7 +29,7 @@ interface IExternalProps {
   expanded?: boolean;
   proposalState: IProposalState;
   /**
-   * unawarded GP rewards due to the current account
+   * unredeemed GP rewards due to the current account
    */
   rewards: IRewardState;
   expired: boolean;
@@ -106,7 +106,7 @@ class ActionButton extends React.Component<IProps, IState> {
       expanded,
       proposalState,
       /**
-       * unawarded GP rewards due to the current account
+       * unredeemed GP rewards due to the current account
        */
       rewards,
     } = this.props;
@@ -118,7 +118,7 @@ class ActionButton extends React.Component<IProps, IState> {
       externalToken: this.props.data.externalTokenBalance,
     };
     /**
-     * unredeemed to the current account
+     * unredeemed by the current account
      */
     const gpRewards = getGpRewards(rewards);
     const currentAccountHasUnredeemedGpRewards = Object.keys(gpRewards).length > 0;
@@ -134,7 +134,7 @@ class ActionButton extends React.Component<IProps, IState> {
     let beneficiaryHasUnredeemedCrRewards = false;
     if (proposalState.contributionReward) {
       /**
-       * unredeemed to the beneficiary
+       * unredeemed by the beneficiary
        */
       const contributionRewards = getCRRewards(proposalState.contributionReward);
       beneficiaryHasUnredeemedCrRewards = Object.keys(contributionRewards).length > 0;

--- a/src/components/Proposal/RedemptionsTip.tsx
+++ b/src/components/Proposal/RedemptionsTip.tsx
@@ -1,10 +1,9 @@
 import { Address, IDAOState, IProposalState, IProposalOutcome, IRewardState } from "@daostack/client";
 import Reputation from "components/Account/Reputation";
-import { claimableContributionRewards, formatTokens, fromWei, getClaimableRewards, tokenSymbol } from "lib/util";
+import { getClaimableContributionRewards, formatTokens, fromWei, getGpRewards, tokenSymbol } from "lib/util";
 import * as React from "react";
 
 interface IProps {
-  beneficiaryHasRewards: boolean;
   currentAccountAddress: Address;
   dao: IDAOState;
   proposal: IProposalState;
@@ -16,7 +15,7 @@ export default (props: IProps) => {
 
   const rewardComponents = [];
   // rewards of current user
-  const claimableRewards = getClaimableRewards(rewardsForCurrentUser);
+  const claimableRewards = getGpRewards(rewardsForCurrentUser);
   let c = null;
   if (claimableRewards.reputationForProposer) {
     c = <div key={rewardsForCurrentUser.id + "_proposer"}>
@@ -60,7 +59,7 @@ export default (props: IProps) => {
 
   let ContributionRewardDiv = <div />;
   if (proposal.winningOutcome === IProposalOutcome.Pass && proposal.contributionReward) {
-    const contributionRewards = claimableContributionRewards(contributionReward);
+    const contributionRewards = getClaimableContributionRewards(contributionReward);
     if (Object.keys(contributionRewards).length > 0) {
       ContributionRewardDiv = <div>
         <strong>

--- a/src/components/Proposal/RedemptionsTip.tsx
+++ b/src/components/Proposal/RedemptionsTip.tsx
@@ -48,7 +48,7 @@ export default (props: IProps) => {
     c = <div key={rewardsForCurrentUser.id + "_staker_bounty"}>
       <strong>For staking on the proposal you will receive:</strong>
       <ul>
-        <li>{fromWei(gpRewards.daoBountyForStaker)} bounty from the DAO (if the DAO has enough GEN)
+        <li>{fromWei(gpRewards.daoBountyForStaker)} bounty from the DAO
         </li>
       </ul>
     </div >;
@@ -92,7 +92,7 @@ export default (props: IProps) => {
 
   }
 
-  return <div>
+  return <div style={{ paddingTop: "8px" }}>
     <React.Fragment>
       { rewardComponents }
     </React.Fragment>

--- a/src/components/Proposal/RedemptionsTip.tsx
+++ b/src/components/Proposal/RedemptionsTip.tsx
@@ -1,25 +1,35 @@
-import { Address, IDAOState, IProposalState, IProposalOutcome, IRewardState } from "@daostack/client";
+import { Address, IDAOState, IProposalState, IProposalOutcome } from "@daostack/client";
 import Reputation from "components/Account/Reputation";
-import { getCRRewards, formatTokens, fromWei, getGpRewards, tokenSymbol } from "lib/util";
+import { formatTokens, fromWei, tokenSymbol, AccountClaimableRewardsType } from "lib/util";
 import * as React from "react";
+import * as css from "components/Shared/PreTransactionModal.scss";
 
 interface IProps {
+  canRewardNone: boolean;
+  canRewardOnlySome: boolean;
+  contributionRewards: AccountClaimableRewardsType;
   currentAccountAddress: Address;
   dao: IDAOState;
+  // non-zero GP rewards of current user, payable or not
+  gpRewards: AccountClaimableRewardsType;
+  id: string;
   proposal: IProposalState;
-  gpRewardsForCurrentUser: IRewardState;
 }
 
 export default (props: IProps) => {
-  const { currentAccountAddress, dao, proposal, gpRewardsForCurrentUser: rewardsForCurrentUser } = props;
+  const { canRewardNone, canRewardOnlySome, currentAccountAddress, contributionRewards, dao, gpRewards, id, proposal } = props;
 
+  const messageDiv = (canRewardNone || canRewardOnlySome) ? <div className={css.message}>
+    <img className={css.icon} src="/assets/images/Icon/Alert-yellow-b.svg" />
+    {canRewardNone ? <div className={css.text}>At this time, none of these rewards can be redeemed -- the DAO does not have the necessary assets.</div> : ""}
+    {canRewardOnlySome ? <div className={css.text}>At this time, only some of these rewards can be redeemed -- the DAO does not have the necessary assets.</div> : ""}
+  </div> : <span></span>;
+  
   const rewardComponents = [];
-  // non-zero GP rewards of current user, payable or not
-  const gpRewards = getGpRewards(rewardsForCurrentUser);
   let c = null;
   if (gpRewards.reputationForProposer) {
-    c = <div key={rewardsForCurrentUser.id + "_proposer"}>
-      <strong>For creating the proposal you will receive:</strong>
+    c = <div key={id + "_proposer"}>
+      <strong>For creating the proposal you are due to receive:</strong>
       <ul>
         <li><Reputation reputation={gpRewards.reputationForProposer} totalReputation={dao.reputationTotalSupply} daoName={dao.name} /></li>
       </ul>
@@ -27,8 +37,8 @@ export default (props: IProps) => {
     rewardComponents.push(c);
   }
   if (gpRewards.reputationForVoter) {
-    c = <div key={rewardsForCurrentUser.id + "_voter"}>
-      <strong>For voting on the proposal you will receive:</strong>
+    c = <div key={id + "_voter"}>
+      <strong>For voting on the proposal you are due to receive:</strong>
       <ul>
         <li><Reputation reputation={gpRewards.reputationForVoter} totalReputation={dao.reputationTotalSupply} daoName={dao.name} /></li>
       </ul>
@@ -36,8 +46,8 @@ export default (props: IProps) => {
     rewardComponents.push(c);
   }
   if (gpRewards.tokensForStaker) {
-    c = <div key={rewardsForCurrentUser.id + "_staker_tokens"}>
-      <strong>For staking on the proposal you will receive:</strong>
+    c = <div key={id + "_staker_tokens"}>
+      <strong>For staking on the proposal you are due to receive:</strong>
       <ul>
         <li>{fromWei(gpRewards.tokensForStaker)} GEN</li>
       </ul>
@@ -45,8 +55,8 @@ export default (props: IProps) => {
     rewardComponents.push(c);
   }
   if (gpRewards.daoBountyForStaker) {
-    c = <div key={rewardsForCurrentUser.id + "_staker_bounty"}>
-      <strong>For staking on the proposal you will receive:</strong>
+    c = <div key={id + "_staker_bounty"}>
+      <strong>For staking on the proposal you are due to receive:</strong>
       <ul>
         <li>{fromWei(gpRewards.daoBountyForStaker)} bounty from the DAO
         </li>
@@ -55,44 +65,45 @@ export default (props: IProps) => {
     rewardComponents.push(c);
   }
 
-  const contributionReward = proposal.contributionReward;
 
   let ContributionRewardDiv = <div />;
-  if (proposal.winningOutcome === IProposalOutcome.Pass && proposal.contributionReward) {
-    const contributionRewards = getCRRewards(contributionReward);
-    if (Object.keys(contributionRewards).length > 0) {
-      ContributionRewardDiv = <div>
-        <strong>
-          {(currentAccountAddress && currentAccountAddress === contributionReward.beneficiary.toLowerCase()) ?
-            "As the beneficiary of the proposal you will recieve" :
-            "The beneficiary of the proposal will receive"}
-        </strong>
-        <ul>
-          {contributionRewards["eth"]  ?
-            <li>
-              {formatTokens(contributionReward.ethReward, "ETH")}
-            </li> : ""
-          }
-          {contributionRewards["externalToken"] ?
-            <li>
-              {formatTokens(contributionRewards["externalToken"], tokenSymbol(contributionReward.externalToken))}
-            </li> : ""
-          }
-          {contributionRewards["rep"] ? <li><Reputation reputation={contributionRewards["rep"]} totalReputation={dao.reputationTotalSupply} daoName={dao.name} /></li> : ""}
+  if (contributionRewards) {
+    const contributionReward = proposal.contributionReward;
+    if (proposal.winningOutcome === IProposalOutcome.Pass && proposal.contributionReward) {
+      if (Object.keys(contributionRewards).length > 0) {
+        ContributionRewardDiv = <div>
+          <strong>
+            {(currentAccountAddress && currentAccountAddress === contributionReward.beneficiary.toLowerCase()) ?
+              "As the beneficiary of the proposal you are due to receive:" :
+              "The beneficiary of the proposal is due to receive:"}
+          </strong>
+          <ul>
+            {contributionRewards["eth"]  ?
+              <li>
+                {formatTokens(contributionReward.ethReward, "ETH")}
+              </li> : ""
+            }
+            {contributionRewards["externalToken"] ?
+              <li>
+                {formatTokens(contributionRewards["externalToken"], tokenSymbol(contributionReward.externalToken))}
+              </li> : ""
+            }
+            {contributionRewards["rep"] ? <li><Reputation reputation={contributionRewards["rep"]} totalReputation={dao.reputationTotalSupply} daoName={dao.name} /></li> : ""}
 
-          {contributionRewards["nativeToken"] ?
-            <li>
-              {formatTokens(contributionRewards["nativeToken"], dao.tokenSymbol)}
-            </li> : ""
-          }
+            {contributionRewards["nativeToken"] ?
+              <li>
+                {formatTokens(contributionRewards["nativeToken"], dao.tokenSymbol)}
+              </li> : ""
+            }
 
-        </ul>
-      </div>;
+          </ul>
+        </div>;
+      }
     }
-
   }
 
-  return <div style={{ paddingTop: "8px" }}>
+  return <div className={css.tipContainer}>
+    { messageDiv }
     <React.Fragment>
       { rewardComponents }
     </React.Fragment>

--- a/src/components/Proposal/RedemptionsTip.tsx
+++ b/src/components/Proposal/RedemptionsTip.tsx
@@ -1,54 +1,54 @@
 import { Address, IDAOState, IProposalState, IProposalOutcome, IRewardState } from "@daostack/client";
 import Reputation from "components/Account/Reputation";
-import { getClaimableContributionRewards, formatTokens, fromWei, getGpRewards, tokenSymbol } from "lib/util";
+import { getCRRewards, formatTokens, fromWei, getGpRewards, tokenSymbol } from "lib/util";
 import * as React from "react";
 
 interface IProps {
   currentAccountAddress: Address;
   dao: IDAOState;
   proposal: IProposalState;
-  rewardsForCurrentUser: IRewardState;
+  gpRewardsForCurrentUser: IRewardState;
 }
 
 export default (props: IProps) => {
-  const { currentAccountAddress, dao, proposal, rewardsForCurrentUser } = props;
+  const { currentAccountAddress, dao, proposal, gpRewardsForCurrentUser: rewardsForCurrentUser } = props;
 
   const rewardComponents = [];
-  // rewards of current user
-  const claimableRewards = getGpRewards(rewardsForCurrentUser);
+  // non-zero GP rewards of current user, payable or not
+  const gpRewards = getGpRewards(rewardsForCurrentUser);
   let c = null;
-  if (claimableRewards.reputationForProposer) {
+  if (gpRewards.reputationForProposer) {
     c = <div key={rewardsForCurrentUser.id + "_proposer"}>
       <strong>For creating the proposal you will receive:</strong>
       <ul>
-        <li><Reputation reputation={claimableRewards.reputationForProposer} totalReputation={dao.reputationTotalSupply} daoName={dao.name} /></li>
+        <li><Reputation reputation={gpRewards.reputationForProposer} totalReputation={dao.reputationTotalSupply} daoName={dao.name} /></li>
       </ul>
     </div>;
     rewardComponents.push(c);
   }
-  if (claimableRewards.reputationForVoter) {
+  if (gpRewards.reputationForVoter) {
     c = <div key={rewardsForCurrentUser.id + "_voter"}>
       <strong>For voting on the proposal you will receive:</strong>
       <ul>
-        <li><Reputation reputation={claimableRewards.reputationForVoter} totalReputation={dao.reputationTotalSupply} daoName={dao.name} /></li>
+        <li><Reputation reputation={gpRewards.reputationForVoter} totalReputation={dao.reputationTotalSupply} daoName={dao.name} /></li>
       </ul>
     </div>;
     rewardComponents.push(c);
   }
-  if (claimableRewards.tokensForStaker) {
+  if (gpRewards.tokensForStaker) {
     c = <div key={rewardsForCurrentUser.id + "_staker_tokens"}>
       <strong>For staking on the proposal you will receive:</strong>
       <ul>
-        <li>{fromWei(claimableRewards.tokensForStaker)} GEN</li>
+        <li>{fromWei(gpRewards.tokensForStaker)} GEN</li>
       </ul>
     </div>;
     rewardComponents.push(c);
   }
-  if (claimableRewards.daoBountyForStaker) {
+  if (gpRewards.daoBountyForStaker) {
     c = <div key={rewardsForCurrentUser.id + "_staker_bounty"}>
       <strong>For staking on the proposal you will receive:</strong>
       <ul>
-        <li>{fromWei(claimableRewards.daoBountyForStaker)} bounty from the DAO (if the DAO has enough GEN)
+        <li>{fromWei(gpRewards.daoBountyForStaker)} bounty from the DAO (if the DAO has enough GEN)
         </li>
       </ul>
     </div >;
@@ -59,7 +59,7 @@ export default (props: IProps) => {
 
   let ContributionRewardDiv = <div />;
   if (proposal.winningOutcome === IProposalOutcome.Pass && proposal.contributionReward) {
-    const contributionRewards = getClaimableContributionRewards(contributionReward);
+    const contributionRewards = getCRRewards(contributionReward);
     if (Object.keys(contributionRewards).length > 0) {
       ContributionRewardDiv = <div>
         <strong>

--- a/src/components/Shared/PreTransactionModal.scss
+++ b/src/components/Shared/PreTransactionModal.scss
@@ -764,3 +764,18 @@ input[type=number] {
     }
   }
 }
+
+.tipContainer {
+  padding-top: 8px;
+
+  .message {
+    padding-bottom: 8px;
+    .icon {
+      display: inline-block;
+      margin-right:6px;
+      position: relative;
+      top: 2px;
+    }
+    .text { display: inline; }
+  }
+}

--- a/src/components/Shared/PreTransactionModal.scss
+++ b/src/components/Shared/PreTransactionModal.scss
@@ -525,6 +525,13 @@ input[type=number] {
         top: -1px;
         display: inline;
 
+        .titleSeparator {
+          display: inline-block;
+          margin: 6px;
+          position: relative;
+          bottom: 2px;
+        }
+
         .transactionEffect {
           font-size: 12px;
           display: inline;

--- a/src/components/Shared/PreTransactionModal.tsx
+++ b/src/components/Shared/PreTransactionModal.tsx
@@ -37,6 +37,7 @@ interface IProps {
   proposal: IProposalState;
   secondaryHeader?: string;
   showNotification: typeof showNotification;
+  multiLineMsg?: boolean;
 }
 
 interface IState {
@@ -78,7 +79,7 @@ class PreTransactionModal extends React.Component<IProps, IState> {
   }
 
   public render(): RenderOutput {
-    const { actionType, beneficiaryProfile, currentAccount, currentAccountGens, dao, effectText, proposal, secondaryHeader } = this.props;
+    const { actionType, beneficiaryProfile, currentAccount, currentAccountGens, dao, effectText, multiLineMsg, proposal, secondaryHeader } = this.props;
     const { stakeAmount } = this.state;
 
     let icon; let transactionType; let rulesHeader; let rules; let actionTypeClass;
@@ -221,7 +222,7 @@ class PreTransactionModal extends React.Component<IProps, IState> {
               <div className={css.transactionIcon}>{icon}</div>
               <div className={css.transactionInfo}>
                 <span className={css.transactionType}>{transactionType}</span>
-                &nbsp; | &nbsp;
+                { !multiLineMsg ? <span className={css.titleSeparator}>|</span>: "" }
                 <span className={css.secondaryHeader}>{secondaryHeader}</span>
                 <div className={css.transactionEffect}>
                   {effectText}

--- a/src/lib/util.ts
+++ b/src/lib/util.ts
@@ -388,8 +388,8 @@ export function hasGpRewards(reward: IRewardState) {
 /**
  * Returns an object describing ContributionReward non-zero, unredeemed reward amounts for the CR beneficiary, optionally
  * filtered by whether the DAO has the funds to pay the rewards.
- * @param  reward unredeemed CR rewards for the current user
- * @return  an array mapping strings to BN
+ * @param  reward unredeemed CR rewards
+ * @param daoBalances 
  */
 export function getCRRewards(reward: IContributionReward, daoBalances: { [key: string]: BN } = {}): AccountClaimableRewardsType {
   const result: AccountClaimableRewardsType = {};

--- a/src/lib/util.ts
+++ b/src/lib/util.ts
@@ -340,7 +340,12 @@ export function linkToEtherScan(address: Address) {
 }
 
 export type AccountClaimableRewardsType = { [key: string]: BN };
-
+/**
+ * Returns an object describing GenesisProtocol non-zero, unredeemed reward amounts for the current user, optionally
+ * filtered by whether the DAO has the funds to pay the rewards.
+ * @param reward unredeemed GP rewards for the current user
+ * @param daoBalances 
+ */
 export function getGpRewards(reward: IRewardState, daoBalances: { [key: string]: BN } = {}): AccountClaimableRewardsType {
   if (!reward) {
     return {};
@@ -381,12 +386,12 @@ export function hasGpRewards(reward: IRewardState) {
 }
 
 /**
- * given an IContributionReward, return an array with the amounts that are still to be claimbed
- * by the beneficiary of the proposal
- * @param  reward an object that immplements IContributionReward
+ * Returns an object describing ContributionReward non-zero, unredeemed reward amounts for the CR beneficiary, optionally
+ * filtered by whether the DAO has the funds to pay the rewards.
+ * @param  reward unredeemed CR rewards for the current user
  * @return  an array mapping strings to BN
  */
-export function getClaimableContributionRewards(reward: IContributionReward, daoBalances: { [key: string]: BN } = {}): AccountClaimableRewardsType {
+export function getCRRewards(reward: IContributionReward, daoBalances: { [key: string]: BN } = {}): AccountClaimableRewardsType {
   const result: AccountClaimableRewardsType = {};
   if (
     reward.ethReward &&


### PR DESCRIPTION
Resolves: https://daostack.tpondemand.com/RestUI/Board.aspx#page=board/5209716961861964288&appConfig=eyJhY2lkIjoiQjgzMTMzNDczNzlCMUI5QUE0RUE1NUVEOUQyQzdFNkIifQ==&boardPopup=bug/1312/silent

I think the UX is a little weird in the case when some redemptions are possible and some aren't.  In that case the Redeem button will not disappear after redeeming.  All that changes is the tooltip over the Redeem button (perhaps only after refreshing the page) and when clicking the Redeem button _again_ you get a failure notification (until the DAO is able to pay out).  I think it would be better if we give the user a warning notification after running Redeem the first time to inform the user that the Redeem did not completely succeed.  @jellegerbrandy 

* shows failure notification when the user tries to redeem but the DAO can't pay out at least part of it
* added ability to determine whether externalToken and GEN rewards can be paid
* cleaned up code to make it more clear  **I recommend you look carefully at the changes.  I commented a lot of code and gave meaningful variable names.  I would like second eyes on whether I have made the right assumptions**
* removed the ugly "-" in the title of the preproposal modal