### PR TITLE
remove most arrow function and .bind lint errors

### DIFF
--- a/src/arc.ts
+++ b/src/arc.ts
@@ -181,6 +181,7 @@ async function checkWeb3ProviderIsForNetwork(provider: any): Promise<string> {
     }
     default: {
       const msg = `Unknown NODE_ENV: ${process.env.NODE_ENV}`;
+      // eslint-disable-next-line no-console
       console.error(msg);
       throw new Error(msg);
     }
@@ -236,6 +237,7 @@ export async function initializeArc(provider?: any): Promise<boolean> {
 
       if (!initializedAccount) {
         // then something went wrong
+        // eslint-disable-next-line no-console
         console.error("Unable to obtain an account from the provider");
         // success = false;
       }
@@ -252,9 +254,11 @@ export async function initializeArc(provider?: any): Promise<boolean> {
       // if this is metamask this should prevent a browser refresh when the network changes
         (window as any).ethereum.autoRefreshOnNetworkChange = false;
       }
+      // eslint-disable-next-line no-console
       console.log(`Connected Arc to ${await getNetworkName(provider.__networkId)}${readonly ? " (readonly)" : ""} `);
     }
   } catch (reason) {
+    // eslint-disable-next-line no-console
     console.error(reason.message);
   }
 
@@ -271,6 +275,7 @@ async function ensureCorrectNetwork(provider: any): Promise<void> {
   const correctNetworkErrorMsg = await checkWeb3ProviderIsForNetwork(provider);
 
   if (correctNetworkErrorMsg) {
+    // eslint-disable-next-line no-console
     console.error(`connected to the wrong network, should be ${correctNetworkErrorMsg}`);
     throw new Error(`Please connect your wallet provider to ${correctNetworkErrorMsg}`);
   }
@@ -279,6 +284,7 @@ async function ensureCorrectNetwork(provider: any): Promise<void> {
 function inTesting(): boolean {
   if (process.env.NODE_ENV === "development" && navigator.webdriver) {
     // in test mode, we have an unlocked ganache and we are not using any wallet
+    // eslint-disable-next-line no-console
     console.log("not using any wallet, because we are in automated test");
     selectedProvider = new Web3(settings.dev.web3Provider);
     return true;
@@ -330,6 +336,7 @@ async function enableWeb3Provider(provider?: any): Promise<void> {
       });
 
     web3Connect.on("error", (error: Error): any => {
+      // eslint-disable-next-line no-console
       console.error(`web3Connect closed on error:  ${error.message}`);
       return rejectOnClosePromise(error);
     });
@@ -349,12 +356,14 @@ async function enableWeb3Provider(provider?: any): Promise<void> {
       await onClosePromise;
 
     } catch (error) {
+      // eslint-disable-next-line no-console
       console.error(`Unable to connect to web3 provider:  ${error.message}`);
       throw new Error("Unable to connect to web3 provider");
     }
 
     if (!provider) {
       // should only be cancelled, errors should have been handled above
+      // eslint-disable-next-line no-console
       console.warn("uncaught error or user cancelled out");
       return;
     }
@@ -372,13 +381,16 @@ async function enableWeb3Provider(provider?: any): Promise<void> {
   try {
     // brings up the provider UI as needed
     await provider.enable();
+    // eslint-disable-next-line no-console
     console.log(`Connected to network provider ${getWeb3ProviderInfo(provider).name}`);
   } catch (ex) {
+    // eslint-disable-next-line no-console
     console.error(`Unable to enable provider: ${ex.message}`);
     throw new Error("Unable to enable provider");
   }
 
   if (!await initializeArc(provider)) {
+    // eslint-disable-next-line no-console
     console.error("Unable to initialize Arc");
     throw new Error("Unable to initialize Arc");
   }
@@ -481,6 +493,7 @@ async function setWeb3Provider(web3ProviderInfo: IWeb3ProviderInfo): Promise<voi
     }
 
   } catch (ex) {
+    // eslint-disable-next-line no-console
     console.error(`Unable to instantiate provider: ${ex.message}`);
     throw new Error("Unable to instantiate provider");
   }
@@ -554,8 +567,10 @@ async function loadCachedWeb3Provider(): Promise<void> {
 
     try {
       await setWeb3Provider(cachedWeb3ProviderInfo);
+      // eslint-disable-next-line no-console
       console.log("using cached web3Provider");
     } catch(ex) {
+      // eslint-disable-next-line no-console
       console.error("failed to instantiate cached web3Provider");
       uncacheWeb3Info();
       throw new Error(ex);
@@ -637,6 +652,7 @@ export async function enableWalletProvider(options: IEnableWalletProviderParams)
 // TODO: check if this (new?) function can replace polling:
 // https://metamask.github.io/metamask-docs/Main_Concepts/Accessing_Accounts
 export function pollForAccountChanges(currentAccountAddress: Address | null, interval = 2000): Observable<Address> {
+  // eslint-disable-next-line no-console
   console.log(`start polling for account changes from: ${currentAccountAddress}`);
   return Observable.create((observer: any): () => void  => {
     let prevAccount = currentAccountAddress;
@@ -662,8 +678,10 @@ export function pollForAccountChanges(currentAccountAddress: Address | null, int
                 prevAccount = account;
               }
             })
+            // eslint-disable-next-line no-console
             .catch((err): void => {console.error(err.message); });
         } catch (ex) {
+          // eslint-disable-next-line no-console
           console.error(ex.message);
         }
         finally {

--- a/src/components/Account/AccountProfilePage.tsx
+++ b/src/components/Account/AccountProfilePage.tsx
@@ -92,7 +92,7 @@ class AccountProfilePage extends React.Component<IProps, null> {
     e.preventDefault();
   }
 
-  public handleFormSubmit = async (values: IFormValues, { _props, setSubmitting, _setErrors }: any): Promise<void>  => {
+  public handleFormSubmit = () => async (values: IFormValues, { _props, setSubmitting, _setErrors }: any): Promise<void> => {
     const { accountAddress, currentAccountAddress, showNotification, updateProfile } = this.props;
 
     if (!await enableWalletProvider({ showNotification })) { return; }
@@ -178,7 +178,7 @@ class AccountProfilePage extends React.Component<IProps, null> {
 
                 return errors;
               }}
-              onSubmit={this.handleFormSubmit}
+              onSubmit={this.handleFormSubmit()}
               // eslint-disable-next-line react/jsx-no-bind
               render={({
                 // eslint-disable-next-line @typescript-eslint/no-unused-vars

--- a/src/components/Account/AccountProfilePage.tsx
+++ b/src/components/Account/AccountProfilePage.tsx
@@ -92,7 +92,7 @@ class AccountProfilePage extends React.Component<IProps, null> {
     e.preventDefault();
   }
 
-  public handleFormSubmit = () => async (values: IFormValues, { _props, setSubmitting, _setErrors }: any): Promise<void> => {
+  public handleFormSubmit = async (values: IFormValues, { _props, setSubmitting, _setErrors }: any): Promise<void> => {
     const { accountAddress, currentAccountAddress, showNotification, updateProfile } = this.props;
 
     if (!await enableWalletProvider({ showNotification })) { return; }
@@ -178,7 +178,7 @@ class AccountProfilePage extends React.Component<IProps, null> {
 
                 return errors;
               }}
-              onSubmit={this.handleFormSubmit()}
+              onSubmit={this.handleFormSubmit}
               // eslint-disable-next-line react/jsx-no-bind
               render={({
                 // eslint-disable-next-line @typescript-eslint/no-unused-vars

--- a/src/components/Account/AccountProfilePage.tsx
+++ b/src/components/Account/AccountProfilePage.tsx
@@ -92,7 +92,7 @@ class AccountProfilePage extends React.Component<IProps, null> {
     e.preventDefault();
   }
 
-  public async handleSubmit(values: IFormValues, { _props, setSubmitting, _setErrors }: any): Promise<void> {
+  public handleFormSubmit = async (values: IFormValues, { _props, setSubmitting, _setErrors }: any): Promise<void>  => {
     const { accountAddress, currentAccountAddress, showNotification, updateProfile } = this.props;
 
     if (!await enableWalletProvider({ showNotification })) { return; }
@@ -134,7 +134,7 @@ class AccountProfilePage extends React.Component<IProps, null> {
     setSubmitting(false);
   }
 
-  public onOAuthSuccess(account: IProfileState) {
+  public onOAuthSuccess = () => (account: IProfileState): void => {
     this.props.verifySocialAccount(this.props.accountAddress, account);
   }
 
@@ -163,6 +163,7 @@ class AccountProfilePage extends React.Component<IProps, null> {
                 description: accountProfile ? accountProfile.description || "" : "",
                 name: accountProfile ? accountProfile.name || "" : "",
               } as IFormValues}
+              // eslint-disable-next-line react/jsx-no-bind
               validate={(values: IFormValues): void => {
                 // const { name } = values;
                 const errors: any = {};
@@ -177,7 +178,8 @@ class AccountProfilePage extends React.Component<IProps, null> {
 
                 return errors;
               }}
-              onSubmit={this.handleSubmit.bind(this)}
+              onSubmit={this.handleFormSubmit}
+              // eslint-disable-next-line react/jsx-no-bind
               render={({
                 // eslint-disable-next-line @typescript-eslint/no-unused-vars
                 values,
@@ -258,8 +260,8 @@ class AccountProfilePage extends React.Component<IProps, null> {
                         }
 
                         <h3>Social Verification</h3>
-                        <OAuthLogin editing={editing} provider="twitter" accountAddress={accountAddress} onSuccess={this.onOAuthSuccess.bind(this)} profile={accountProfile} socket={socket} />
-                        <OAuthLogin editing={editing} provider="github" accountAddress={accountAddress} onSuccess={this.onOAuthSuccess.bind(this)} profile={accountProfile} socket={socket} />
+                        <OAuthLogin editing={editing} provider="twitter" accountAddress={accountAddress} onSuccess={this.onOAuthSuccess()} profile={accountProfile} socket={socket} />
+                        <OAuthLogin editing={editing} provider="github" accountAddress={accountAddress} onSuccess={this.onOAuthSuccess()} profile={accountProfile} socket={socket} />
                       </div>
                     }
                     <div className={css.otherInfoContainer}>

--- a/src/components/Account/AccountProfilePage.tsx
+++ b/src/components/Account/AccountProfilePage.tsx
@@ -134,7 +134,7 @@ class AccountProfilePage extends React.Component<IProps, null> {
     setSubmitting(false);
   }
 
-  public onOAuthSuccess = () => (account: IProfileState): void => {
+  public onOAuthSuccess = (account: IProfileState): void => {
     this.props.verifySocialAccount(this.props.accountAddress, account);
   }
 
@@ -260,8 +260,8 @@ class AccountProfilePage extends React.Component<IProps, null> {
                         }
 
                         <h3>Social Verification</h3>
-                        <OAuthLogin editing={editing} provider="twitter" accountAddress={accountAddress} onSuccess={this.onOAuthSuccess()} profile={accountProfile} socket={socket} />
-                        <OAuthLogin editing={editing} provider="github" accountAddress={accountAddress} onSuccess={this.onOAuthSuccess()} profile={accountProfile} socket={socket} />
+                        <OAuthLogin editing={editing} provider="twitter" accountAddress={accountAddress} onSuccess={this.onOAuthSuccess} profile={accountProfile} socket={socket} />
+                        <OAuthLogin editing={editing} provider="github" accountAddress={accountAddress} onSuccess={this.onOAuthSuccess} profile={accountProfile} socket={socket} />
                       </div>
                     }
                     <div className={css.otherInfoContainer}>

--- a/src/components/Account/OAuthLogin.tsx
+++ b/src/components/Account/OAuthLogin.tsx
@@ -76,7 +76,7 @@ export default class OAuthLogin extends React.Component<IProps, IState> {
   // Kicks off the processes of opening the popup on the server and listening
   // to the popup. It also disables the login button so the user can not
   // attempt to login to the provider twice.
-  public startAuth = () => (e: any) => {
+  public startAuth = (e: any) => {
     if (!this.state.disabled) {
       e.preventDefault();
       this.popup = this.openPopup();
@@ -103,7 +103,7 @@ export default class OAuthLogin extends React.Component<IProps, IState> {
           : (editing
             ? <div>
               <button
-                onClick={this.startAuth()}
+                onClick={this.startAuth}
                 disabled={disabled}
               >
                 <FontAwesomeIcon icon={["fab", provider]} className={css.icon}/>

--- a/src/components/Account/OAuthLogin.tsx
+++ b/src/components/Account/OAuthLogin.tsx
@@ -76,7 +76,7 @@ export default class OAuthLogin extends React.Component<IProps, IState> {
   // Kicks off the processes of opening the popup on the server and listening
   // to the popup. It also disables the login button so the user can not
   // attempt to login to the provider twice.
-  public startAuth(e: any) {
+  public startAuth = () => (e: any) => {
     if (!this.state.disabled) {
       e.preventDefault();
       this.popup = this.openPopup();
@@ -103,7 +103,7 @@ export default class OAuthLogin extends React.Component<IProps, IState> {
           : (editing
             ? <div>
               <button
-                onClick={this.startAuth.bind(this)}
+                onClick={this.startAuth()}
                 disabled={disabled}
               >
                 <FontAwesomeIcon icon={["fab", provider]} className={css.icon}/>

--- a/src/components/Dao/DaoContainer.tsx
+++ b/src/components/Dao/DaoContainer.tsx
@@ -60,9 +60,22 @@ class DaoContainer extends React.Component<IProps, null> {
     this.props.getProfilesForAllAccounts();
   }
 
+  private daoHistoryRoute = () => (routeProps: any) => <DaoHistoryPage {...routeProps} currentAccountAddress={this.props.currentAccountAddress} />;
+  private daoMembersRoute = () => (routeProps: any) => <DaoMembersPage {...routeProps} daoState={this.props.data} />;
+  private daoDiscussionRoute = () => (routeProps: any) => <DaoDiscussionPage {...routeProps} dao={this.props.data} />;
+  private daoProposalRoute = () => (routeProps: any) =>
+    <ProposalDetailsPage {...routeProps}
+      daoState={this.props.data}
+      currentAccountAddress={this.props.currentAccountAddress}
+      proposalId={routeProps.match.params.proposalId}
+    />;
+
+  private schemeRoute = () => (routeProps: any) => <SchemeContainer {...routeProps} daoState={this.props.data} currentAccountAddress={this.props.currentAccountAddress} />;
+  private daoSchemesRoute = () => (routeProps: any) => <DaoSchemesPage {...routeProps} />;
+  private modalRoute = (route: any) => `/dao/${route.params.daoAvatarAddress}/scheme/${route.params.schemeId}/`;
+
   public render(): RenderOutput {
     const daoState = this.props.data;
-    const { currentAccountAddress } = this.props;
 
     return (
       <div className={css.outer}>
@@ -80,31 +93,25 @@ class DaoContainer extends React.Component<IProps, null> {
           </div>
           <Switch>
             <Route exact path="/dao/:daoAvatarAddress/history"
-              render={(props) => <DaoHistoryPage {...props} currentAccountAddress={currentAccountAddress} />} />
+              render={this.daoHistoryRoute()} />
             <Route exact path="/dao/:daoAvatarAddress/members"
-              render={(props) => <DaoMembersPage {...props} daoState={daoState} />} />
+              render={this.daoMembersRoute()} />
             <Route exact path="/dao/:daoAvatarAddress/discussion"
-              render={(props) => <DaoDiscussionPage {...props} dao={daoState} />} />
+              render={this.daoDiscussionRoute()} />
 
             <Route exact path="/dao/:daoAvatarAddress/proposal/:proposalId"
-              render={(props) =>
-                <ProposalDetailsPage {...props}
-                  daoState={daoState}
-                  currentAccountAddress={currentAccountAddress}
-                  proposalId={props.match.params.proposalId}
-                />
-              }
+              render={this.daoProposalRoute()}
             />
 
             <Route path="/dao/:daoAvatarAddress/scheme/:schemeId"
-              render={(props) => <SchemeContainer {...props} daoState={daoState} currentAccountAddress={currentAccountAddress} />} />
+              render={this.schemeRoute()} />
 
-            <Route path="/dao/:daoAvatarAddress" render={(props) => <DaoSchemesPage {...props} />} />
+            <Route path="/dao/:daoAvatarAddress" render={this.daoSchemesRoute()} />
           </Switch>
 
           <ModalRoute
             path="/dao/:daoAvatarAddress/scheme/:schemeId/proposals/create"
-            parentPath={(route: any) => `/dao/${route.params.daoAvatarAddress}/scheme/${route.params.schemeId}/`}
+            parentPath={this.modalRoute}
             component={CreateProposalPage}
           />
 

--- a/src/components/Dao/DaoContainer.tsx
+++ b/src/components/Dao/DaoContainer.tsx
@@ -60,18 +60,18 @@ class DaoContainer extends React.Component<IProps, null> {
     this.props.getProfilesForAllAccounts();
   }
 
-  private daoHistoryRoute = () => (routeProps: any) => <DaoHistoryPage {...routeProps} currentAccountAddress={this.props.currentAccountAddress} />;
-  private daoMembersRoute = () => (routeProps: any) => <DaoMembersPage {...routeProps} daoState={this.props.data} />;
-  private daoDiscussionRoute = () => (routeProps: any) => <DaoDiscussionPage {...routeProps} dao={this.props.data} />;
-  private daoProposalRoute = () => (routeProps: any) =>
+  private daoHistoryRoute = (routeProps: any) => <DaoHistoryPage {...routeProps} currentAccountAddress={this.props.currentAccountAddress} />;
+  private daoMembersRoute = (routeProps: any) => <DaoMembersPage {...routeProps} daoState={this.props.data} />;
+  private daoDiscussionRoute = (routeProps: any) => <DaoDiscussionPage {...routeProps} dao={this.props.data} />;
+  private daoProposalRoute = (routeProps: any) =>
     <ProposalDetailsPage {...routeProps}
       daoState={this.props.data}
       currentAccountAddress={this.props.currentAccountAddress}
       proposalId={routeProps.match.params.proposalId}
     />;
 
-  private schemeRoute = () => (routeProps: any) => <SchemeContainer {...routeProps} daoState={this.props.data} currentAccountAddress={this.props.currentAccountAddress} />;
-  private daoSchemesRoute = () => (routeProps: any) => <DaoSchemesPage {...routeProps} />;
+  private schemeRoute = (routeProps: any) => <SchemeContainer {...routeProps} daoState={this.props.data} currentAccountAddress={this.props.currentAccountAddress} />;
+  private daoSchemesRoute = (routeProps: any) => <DaoSchemesPage {...routeProps} />;
   private modalRoute = (route: any) => `/dao/${route.params.daoAvatarAddress}/scheme/${route.params.schemeId}/`;
 
   public render(): RenderOutput {
@@ -93,20 +93,20 @@ class DaoContainer extends React.Component<IProps, null> {
           </div>
           <Switch>
             <Route exact path="/dao/:daoAvatarAddress/history"
-              render={this.daoHistoryRoute()} />
+              render={this.daoHistoryRoute} />
             <Route exact path="/dao/:daoAvatarAddress/members"
-              render={this.daoMembersRoute()} />
+              render={this.daoMembersRoute} />
             <Route exact path="/dao/:daoAvatarAddress/discussion"
-              render={this.daoDiscussionRoute()} />
+              render={this.daoDiscussionRoute} />
 
             <Route exact path="/dao/:daoAvatarAddress/proposal/:proposalId"
-              render={this.daoProposalRoute()}
+              render={this.daoProposalRoute}
             />
 
             <Route path="/dao/:daoAvatarAddress/scheme/:schemeId"
-              render={this.schemeRoute()} />
+              render={this.schemeRoute} />
 
-            <Route path="/dao/:daoAvatarAddress" render={this.daoSchemesRoute()} />
+            <Route path="/dao/:daoAvatarAddress" render={this.daoSchemesRoute} />
           </Switch>
 
           <ModalRoute

--- a/src/components/Dao/DaoSidebar.tsx
+++ b/src/components/Dao/DaoSidebar.tsx
@@ -53,7 +53,7 @@ class DaoSidebar extends React.Component<IProps, IStateProps> {
     super(props);
   }
 
-  private handleCloseMenu = () => (_event: any): void => {
+  private handleCloseMenu = (_event: any): void => {
     this.props.hideMenu();
   }
 
@@ -73,7 +73,7 @@ class DaoSidebar extends React.Component<IProps, IStateProps> {
       <div className={menuClass}>
         <div className={css.daoNavigation}>
           <div className={css.daoName}>
-            <Link to={"/dao/" + dao.address} onClick={this.handleCloseMenu()}>
+            <Link to={"/dao/" + dao.address} onClick={this.handleCloseMenu}>
               <b className={css.daoIcon} style={{ backgroundImage: bgPattern.toDataUrl() }}></b>
               <em></em>
               <span>{dao.name}</span>
@@ -104,7 +104,7 @@ class DaoSidebar extends React.Component<IProps, IStateProps> {
             <span className={css.navHeading}><b>Menu</b></span>
             <ul>
               <li>
-                <Link to={"/dao/" + dao.address} onClick={this.handleCloseMenu()}>
+                <Link to={"/dao/" + dao.address} onClick={this.handleCloseMenu}>
                   <span className={css.menuDot} />
                   <span className={
                     classNames({
@@ -118,7 +118,7 @@ class DaoSidebar extends React.Component<IProps, IStateProps> {
               </li>
               <li>
                 <TrainingTooltip placement="topLeft" overlay={"List of entities (DAOs and individuals) that have voting power in the DAO"}>
-                  <Link to={"/dao/" + dao.address + "/members/"} onClick={this.handleCloseMenu()}>
+                  <Link to={"/dao/" + dao.address + "/members/"} onClick={this.handleCloseMenu}>
                     <span className={css.menuDot} />
                     <span className={
                       classNames({
@@ -132,7 +132,7 @@ class DaoSidebar extends React.Component<IProps, IStateProps> {
                 </TrainingTooltip>
               </li>
               <li>
-                <Link to={"/dao/" + dao.address + "/history/"} onClick={this.handleCloseMenu()}>
+                <Link to={"/dao/" + dao.address + "/history/"} onClick={this.handleCloseMenu}>
                   <span className={css.menuDot} />
                   <span className={
                     classNames({
@@ -146,7 +146,7 @@ class DaoSidebar extends React.Component<IProps, IStateProps> {
               </li>
               <li>
                 <TrainingTooltip placement="topLeft" overlay={"Space designated for general questions, statements and comments"}>
-                  <Link to={"/dao/" + dao.address + "/discussion/"} onClick={this.handleCloseMenu()}>
+                  <Link to={"/dao/" + dao.address + "/discussion/"} onClick={this.handleCloseMenu}>
                     <span className={
                       classNames({
                         [css.menuDot]: true,
@@ -182,7 +182,7 @@ class DaoSidebar extends React.Component<IProps, IStateProps> {
           </div>
           <div className={css.menuWrapper}>
             <ul>
-              <li><Link to="/" onClick={this.handleCloseMenu()}>Home</Link></li>
+              <li><Link to="/" onClick={this.handleCloseMenu}>Home</Link></li>
               <li>
                 <a>Buy GEN</a>
                 <ul>

--- a/src/components/Daos/DaoCard.tsx
+++ b/src/components/Daos/DaoCard.tsx
@@ -13,12 +13,14 @@ interface IExternalProps {
 
 type IProps = IExternalProps & ISubscriptionProps<IDAOState>
 
+
 const DaoCard = (props: IProps) => {
   const { dao } = props;
   const daoState = props.data;
   const bgPattern = GeoPattern.generate(dao.id + daoState.name);
   const dxDaoActivationDate = moment("2019-07-14T12:00:00.000+0000");
   const inActive = (daoState.name === "dxDAO") && dxDaoActivationDate.isSameOrAfter(moment());
+  const handleCLick = (e: any) => { if (inActive) { e.preventDefault(); } };
 
   return (
     <Link
@@ -26,7 +28,7 @@ const DaoCard = (props: IProps) => {
       to={"/dao/" + dao.id}
       key={"dao_" + dao.id}
       data-test-id="dao-link"
-      onClick={(e) => { if (inActive) { e.preventDefault(); } }}
+      onClick={handleCLick}
     >
       <div className={classNames({
         [css.dao]: true,

--- a/src/components/Daos/DaoCard.tsx
+++ b/src/components/Daos/DaoCard.tsx
@@ -20,7 +20,7 @@ const DaoCard = (props: IProps) => {
   const bgPattern = GeoPattern.generate(dao.id + daoState.name);
   const dxDaoActivationDate = moment("2019-07-14T12:00:00.000+0000");
   const inActive = (daoState.name === "dxDAO") && dxDaoActivationDate.isSameOrAfter(moment());
-  const handleCLick = (e: any) => { if (inActive) { e.preventDefault(); } };
+  const handleClick = (e: any) => { if (inActive) { e.preventDefault(); } };
 
   return (
     <Link
@@ -28,7 +28,7 @@ const DaoCard = (props: IProps) => {
       to={"/dao/" + dao.id}
       key={"dao_" + dao.id}
       data-test-id="dao-link"
-      onClick={handleCLick}
+      onClick={handleClick}
     >
       <div className={classNames({
         [css.dao]: true,

--- a/src/components/Notification/MinimizedNotifications.tsx
+++ b/src/components/Notification/MinimizedNotifications.tsx
@@ -9,8 +9,10 @@ interface IProps {
 
 export default class Notification extends React.Component<IProps, null> {
 
+  private unmimimize = () => { this.props.unminimize(); };
+
   public render(): RenderOutput {
-    const { notifications, unminimize } = this.props;
+    const { notifications } = this.props;
 
     const transactionClass = classNames({
       [css.pendingTransaction]: true,
@@ -21,7 +23,7 @@ export default class Notification extends React.Component<IProps, null> {
     });
 
     return (
-      <div style={{cursor: "pointer"}} className={transactionClass} onClick={() => unminimize()}>
+      <div style={{cursor: "pointer"}} className={transactionClass} onClick={this.unmimimize}>
         <div className={css.statusIcon}>
           <b style={{whiteSpace: "nowrap"}}>{notifications} alert{notifications > 1 ? "s" : ""}</b>
         </div>

--- a/src/components/Notification/MinimizedNotifications.tsx
+++ b/src/components/Notification/MinimizedNotifications.tsx
@@ -9,7 +9,7 @@ interface IProps {
 
 export default class Notification extends React.Component<IProps, null> {
 
-  private unmimimize = () => () => { this.props.unminimize(); };
+  private unmimimize = () => { this.props.unminimize(); };
 
   public render(): RenderOutput {
     const { notifications } = this.props;
@@ -23,7 +23,7 @@ export default class Notification extends React.Component<IProps, null> {
     });
 
     return (
-      <div style={{cursor: "pointer"}} className={transactionClass} onClick={this.unmimimize()}>
+      <div style={{cursor: "pointer"}} className={transactionClass} onClick={this.unmimimize}>
         <div className={css.statusIcon}>
           <b style={{whiteSpace: "nowrap"}}>{notifications} alert{notifications > 1 ? "s" : ""}</b>
         </div>

--- a/src/components/Notification/MinimizedNotifications.tsx
+++ b/src/components/Notification/MinimizedNotifications.tsx
@@ -9,7 +9,7 @@ interface IProps {
 
 export default class Notification extends React.Component<IProps, null> {
 
-  private unmimimize = () => { this.props.unminimize(); };
+  private unmimimize = () => () => { this.props.unminimize(); };
 
   public render(): RenderOutput {
     const { notifications } = this.props;
@@ -23,7 +23,7 @@ export default class Notification extends React.Component<IProps, null> {
     });
 
     return (
-      <div style={{cursor: "pointer"}} className={transactionClass} onClick={this.unmimimize}>
+      <div style={{cursor: "pointer"}} className={transactionClass} onClick={this.unmimimize()}>
         <div className={css.statusIcon}>
           <b style={{whiteSpace: "nowrap"}}>{notifications} alert{notifications > 1 ? "s" : ""}</b>
         </div>

--- a/src/components/Proposal/ActionButton.tsx
+++ b/src/components/Proposal/ActionButton.tsx
@@ -87,7 +87,7 @@ class ActionButton extends React.Component<IProps, IState> {
     }
   }
 
-  private closePreRedeemModal = () => (): void => {
+  private closePreRedeemModal = (): void => {
     this.setState({ preRedeemModalOpen: false });
   }
 
@@ -186,7 +186,7 @@ class ActionButton extends React.Component<IProps, IState> {
             actionType={ActionTypes.Redeem}
             action={this.handleRedeemProposal}
             beneficiaryProfile={beneficiaryProfile}
-            closeAction={this.closePreRedeemModal()}
+            closeAction={this.closePreRedeemModal}
             dao={daoState}
             effectText={redemptionsTip}
             proposal={proposalState}

--- a/src/components/Proposal/ActionButton.tsx
+++ b/src/components/Proposal/ActionButton.tsx
@@ -70,7 +70,7 @@ class ActionButton extends React.Component<IProps, IState> {
     this.handleRedeemProposal = this.handleRedeemProposal.bind(this);
   }
 
-  private handleClickExecute = () => async(): Promise<void> => {
+  private handleClickExecute = async (): Promise<void> => {
     if (!await enableWalletProvider({ showNotification: this.props.showNotification })) { return; }
 
     await this.props.executeProposal(this.props.daoState.address, this.props.proposalState.id, this.props.currentAccountAddress);
@@ -195,23 +195,23 @@ class ActionButton extends React.Component<IProps, IState> {
         }
 
         { proposalState.stage === IProposalStage.Queued && proposalState.upstakeNeededToPreBoost.lt(new BN(0)) ?
-          <button className={css.preboostButton} onClick={this.handleClickExecute()} data-test-id="buttonBoost">
+          <button className={css.preboostButton} onClick={this.handleClickExecute} data-test-id="buttonBoost">
             <img src="/assets/images/Icon/boost.svg"/>
             { /* space after <span> is there on purpose */ }
             <span> Pre-Boost</span>
           </button> :
           proposalState.stage === IProposalStage.PreBoosted && expired && proposalState.downStakeNeededToQueue.lte(new BN(0)) ?
-            <button className={css.unboostButton} onClick={this.handleClickExecute()} data-test-id="buttonBoost">
+            <button className={css.unboostButton} onClick={this.handleClickExecute} data-test-id="buttonBoost">
               <img src="/assets/images/Icon/boost.svg"/>
               <span> Un-Boost</span>
             </button> :
             proposalState.stage === IProposalStage.PreBoosted && expired ?
-              <button className={css.boostButton} onClick={this.handleClickExecute()} data-test-id="buttonBoost">
+              <button className={css.boostButton} onClick={this.handleClickExecute} data-test-id="buttonBoost">
                 <img src="/assets/images/Icon/boost.svg"/>
                 <span> Boost</span>
               </button> :
               (proposalState.stage === IProposalStage.Boosted || proposalState.stage === IProposalStage.QuietEndingPeriod) && expired ?
-                <button className={css.executeButton} onClick={this.handleClickExecute()}>
+                <button className={css.executeButton} onClick={this.handleClickExecute}>
                   <img src="/assets/images/Icon/execute.svg"/>
                   { /* space after <span> is there on purpose */ }
                   <span> Execute</span>

--- a/src/components/Proposal/Create/SchemeForms/CreateContributionRewardProposal.tsx
+++ b/src/components/Proposal/Create/SchemeForms/CreateContributionRewardProposal.tsx
@@ -131,7 +131,7 @@ class CreateContributionReward extends React.Component<IProps, IStateProps> {
     this.props.handleClose();
   }
 
-  private onTagsChange = () => (tags: string[]): void => {
+  private onTagsChange = (tags: string[]): void => {
     this.setState({tags});
   }
 
@@ -258,7 +258,7 @@ class CreateContributionReward extends React.Component<IProps, IStateProps> {
               </TrainingTooltip>
 
               <div className={css.tagSelectorContainer}>
-                <TagsSelector onChange={this.onTagsChange()}></TagsSelector>
+                <TagsSelector onChange={this.onTagsChange}></TagsSelector>
               </div>
 
               <TrainingTooltip overlay="Link to the fully detailed description of your proposal" placement="right">

--- a/src/components/Proposal/Create/SchemeForms/CreateKnownGenericSchemeProposal.tsx
+++ b/src/components/Proposal/Create/SchemeForms/CreateKnownGenericSchemeProposal.tsx
@@ -189,7 +189,7 @@ class CreateKnownSchemeProposal extends React.Component<IProps, IState> {
     />;
   }
 
-  private onTagsChange = () => (tags: any[]): void => {
+  private onTagsChange = (tags: any[]): void => {
     this.setState({tags});
   }
 
@@ -369,7 +369,7 @@ class CreateKnownSchemeProposal extends React.Component<IProps, IState> {
                   </label>
 
                   <div className={css.tagSelectorContainer}>
-                    <TagsSelector onChange={this.onTagsChange()}></TagsSelector>
+                    <TagsSelector onChange={this.onTagsChange}></TagsSelector>
                   </div>
 
                   <label htmlFor="urlInput">

--- a/src/components/Proposal/Create/SchemeForms/CreateKnownGenericSchemeProposal.tsx
+++ b/src/components/Proposal/Create/SchemeForms/CreateKnownGenericSchemeProposal.tsx
@@ -56,8 +56,6 @@ class CreateKnownSchemeProposal extends React.Component<IProps, IState> {
   constructor(props: IProps) {
     super(props);
 
-    this.handleSubmit = this.handleSubmit.bind(this);
-
     if (!props.genericSchemeInfo) {
       throw Error("GenericSchemeInfo should be provided");
     }
@@ -70,7 +68,7 @@ class CreateKnownSchemeProposal extends React.Component<IProps, IState> {
     };
   }
 
-  private handleSubmit = () => async (values: IFormValues, { setSubmitting }: any ): Promise<void> => {
+  private handleSubmit = async (values: IFormValues, { setSubmitting }: any ): Promise<void> => {
     if (!await enableWalletProvider({ showNotification: this.props.showNotification })) { return; }
 
     const currentAction = this.state.currentAction;
@@ -319,7 +317,7 @@ class CreateKnownSchemeProposal extends React.Component<IProps, IState> {
               }
               return errors;
             }}
-            onSubmit={this.handleSubmit()}
+            onSubmit={this.handleSubmit}
             // eslint-disable-next-line react/jsx-no-bind
             render={({
               errors,

--- a/src/components/Proposal/Create/SchemeForms/CreateSchemeRegistrarProposal.tsx
+++ b/src/components/Proposal/Create/SchemeForms/CreateSchemeRegistrarProposal.tsx
@@ -117,7 +117,7 @@ class CreateSchemeRegistrarProposal extends React.Component<IProps, IState> {
     this.setState({ currentTab: tab });
   }
 
-  private onTagsChange = () => (tags: any[]): void => {
+  private onTagsChange = (tags: any[]): void => {
     this.setState({tags});
   }
 
@@ -292,7 +292,7 @@ class CreateSchemeRegistrarProposal extends React.Component<IProps, IState> {
                   </TrainingTooltip>
 
                   <div className={css.tagSelectorContainer}>
-                    <TagsSelector onChange={this.onTagsChange()}></TagsSelector>
+                    <TagsSelector onChange={this.onTagsChange}></TagsSelector>
                   </div>
 
                   <TrainingTooltip overlay="Link to the fully detailed description of your proposal" placement="right">

--- a/src/components/Proposal/Create/SchemeForms/CreateUnknownGenericSchemeProposal.tsx
+++ b/src/components/Proposal/Create/SchemeForms/CreateUnknownGenericSchemeProposal.tsx
@@ -66,7 +66,7 @@ class CreateGenericScheme extends React.Component<IProps, IStateProps> {
     this.props.handleClose();
   }
 
-  private onTagsChange = () => (tags: any[]): void => {
+  private onTagsChange = (tags: any[]): void => {
     this.setState({tags});
   }
 
@@ -180,7 +180,7 @@ class CreateGenericScheme extends React.Component<IProps, IStateProps> {
               </TrainingTooltip>
 
               <div className={css.tagSelectorContainer}>
-                <TagsSelector onChange={this.onTagsChange()}></TagsSelector>
+                <TagsSelector onChange={this.onTagsChange}></TagsSelector>
               </div>
 
               <TrainingTooltip overlay="Link to the fully detailed description of your proposal" placement="right">

--- a/src/components/Proposal/Create/SchemeForms/MarkdownField.tsx
+++ b/src/components/Proposal/Create/SchemeForms/MarkdownField.tsx
@@ -24,6 +24,9 @@ export default class MarkdownField extends React.Component<Props, IState> {
     };
   }
 
+  private generateMarkdownPreview = (markdown: any) => Promise.resolve(<ReactMarkdown source={markdown} />);
+  private onTabChange = () => (tab: any) => { this.setState({ selectedTab: tab}); };
+
   public render(): RenderOutput {
     const { field, onChange } = this.props;
 
@@ -42,14 +45,12 @@ export default class MarkdownField extends React.Component<Props, IState> {
       <div>
         <ReactMde
           commands={usedCommands}
-          generateMarkdownPreview={(markdown) =>
-            Promise.resolve(<ReactMarkdown source={markdown} />)
-          }
+          generateMarkdownPreview={this.generateMarkdownPreview}
           maxEditorHeight={84}
           minEditorHeight={84}
           minPreviewHeight={74}
           onChange={onChange}
-          onTabChange={(tab) => { this.setState({ selectedTab: tab}); }}
+          onTabChange={this.onTabChange()}
           selectedTab={this.state.selectedTab}
           value={field.value}
         />

--- a/src/components/Proposal/Create/SchemeForms/MarkdownField.tsx
+++ b/src/components/Proposal/Create/SchemeForms/MarkdownField.tsx
@@ -25,7 +25,7 @@ export default class MarkdownField extends React.Component<Props, IState> {
   }
 
   private generateMarkdownPreview = (markdown: any) => Promise.resolve(<ReactMarkdown source={markdown} />);
-  private onTabChange = () => (tab: any) => { this.setState({ selectedTab: tab}); };
+  private onTabChange = (tab: any) => { this.setState({ selectedTab: tab}); };
 
   public render(): RenderOutput {
     const { field, onChange } = this.props;
@@ -50,7 +50,7 @@ export default class MarkdownField extends React.Component<Props, IState> {
           minEditorHeight={84}
           minPreviewHeight={74}
           onChange={onChange}
-          onTabChange={this.onTabChange()}
+          onTabChange={this.onTabChange}
           selectedTab={this.state.selectedTab}
           value={field.value}
         />

--- a/src/components/Proposal/Create/SchemeForms/TagsSelector.tsx
+++ b/src/components/Proposal/Create/SchemeForms/TagsSelector.tsx
@@ -60,19 +60,19 @@ class TagsSelector extends React.Component<IProps, IStateProps> {
     }
   }
 
-  private handleDelete = () => (i: number): void => {
+  private handleDelete = (i: number): void => {
     const tags = this.state.workingTags.filter((_tag: Tag, index: number) => index !== i);
     this.setState({ workingTags: tags });
     this.emitOnChange(tags);
   }
  
-  private handleAddition = () => (tag: Tag): void => {
+  private handleAddition = (tag: Tag): void => {
     const tags = [...this.state.workingTags, tag];
     this.setState({ workingTags:  tags });
     this.emitOnChange(tags);
   }
 
-  private handleBlur = () => (): void => {
+  private handleBlur = (): void => {
     const inputText = (this.tagsComponent.current.getElementsByClassName("ReactTags__tagInputField")[0] as HTMLInputElement).value;
     if (inputText) {
       let alreadyHas = false;
@@ -84,7 +84,7 @@ class TagsSelector extends React.Component<IProps, IStateProps> {
         }
       }
       if (!alreadyHas) {
-        this.handleAddition()({ id: inputText, text: inputText });
+        this.handleAddition({ id: inputText, text: inputText });
       }
     }
   }
@@ -139,9 +139,9 @@ class TagsSelector extends React.Component<IProps, IStateProps> {
       <ReactTags
         tags={workingTags}
         suggestions={suggestions}
-        handleDelete={this.handleDelete()}
-        handleAddition={this.handleAddition()}
-        handleInputBlur={this.handleBlur()}
+        handleDelete={this.handleDelete}
+        handleAddition={this.handleAddition}
+        handleInputBlur={this.handleBlur}
         delimiters={delimiters}
         autocomplete={1}
         readOnly={!!readOnly}

--- a/src/components/Proposal/Create/SchemeForms/TagsSelector.tsx
+++ b/src/components/Proposal/Create/SchemeForms/TagsSelector.tsx
@@ -105,6 +105,8 @@ class TagsSelector extends React.Component<IProps, IStateProps> {
     return map;
   }
 
+  private suggestionHtml = ( tag: ITagEx ) => <div>{tag.text} <span className="count">({tag.count})</span></div>;
+
   public render(): RenderOutput {
     const { workingTags } = this.state;
     const { readOnly, darkTheme } = this.props;
@@ -145,8 +147,7 @@ class TagsSelector extends React.Component<IProps, IStateProps> {
         readOnly={!!readOnly}
         autofocus={false}
         allowDragDrop={false} // because we have no way to persist the tab order
-        // eslint-disable-next-line react/jsx-no-bind
-        renderSuggestion = {( tag: ITagEx ) => <div>{tag.text} <span className="count">({tag.count})</span></div>}
+        renderSuggestion = {this.suggestionHtml}
       />
     </div>;
   }

--- a/src/components/Proposal/ProposalSummary/ProposalSummaryKnownGenericScheme.tsx
+++ b/src/components/Proposal/ProposalSummary/ProposalSummaryKnownGenericScheme.tsx
@@ -22,6 +22,10 @@ export default class ProposalSummary extends React.Component<IProps> {
     super(props);
   }
 
+  private inputHtml = (x: any) => <span key={x.name}>{x.name} {x.type}, </span>;
+  private callDataHtml = (value: any) => <div key={value}>{value}</div>;
+
+
   public render(): RenderOutput {
     const { proposal, detailView, transactionModal, genericSchemeInfo } = this.props;
     if (genericSchemeInfo.specs.name === "DutchX") {
@@ -61,9 +65,9 @@ export default class ProposalSummary extends React.Component<IProps> {
         <div className={css.summaryDetails}>
           Executing this proposal will call the function
           <pre>{ decodedCallData.action.abi.name}
-        ({ decodedCallData.action.abi.inputs.map((x: any) => <span key={x.name}>{x.name} {x.type}, </span>) })
+        ({ decodedCallData.action.abi.inputs.map(this.inputHtml) })
           </pre>
-          with values <pre>{ decodedCallData.values.map((value: any) => <div key={value}>{value}</div>)}</pre>
+          with values <pre>{ decodedCallData.values.map(this.callDataHtml)}</pre>
           on contract at
           <pre><a href={linkToEtherScan(proposal.genericScheme.contractToCall)}>{proposal.genericScheme.contractToCall}</a></pre>
         </div>

--- a/src/components/Proposal/ProposalSummary/ProposalSummarySchemeRegistrar.tsx
+++ b/src/components/Proposal/ProposalSummary/ProposalSummarySchemeRegistrar.tsx
@@ -1,4 +1,4 @@
-import { IDAOState, IProposalState, IProposalType } from "@daostack/client";
+import { IDAOState, IProposalState, IProposalType, ISchemeRegistrar } from "@daostack/client";
 import * as classNames from "classnames";
 import { copyToClipboard, getNetworkName, linkToEtherScan, schemeNameAndAddress } from "lib/util";
 import * as React from "react";
@@ -31,6 +31,9 @@ export default class ProposalSummary extends React.Component<IProps, IState> {
   public async UNSAFE_componentWillMount(): Promise<void> {
     this.setState({ network: (await getNetworkName()).toLowerCase() });
   }
+
+  private copySchemeAddressOnClick = (schemeRegistrar: ISchemeRegistrar) => (): void => copyToClipboard(schemeRegistrar.schemeToRegister);
+  private copySchemeParamsHashOnClick = (schemeRegistrar: ISchemeRegistrar) => (): void => copyToClipboard(schemeRegistrar.schemeToRegisterParamsHash);
 
   public render(): RenderOutput {
     const { proposal, detailView, transactionModal } = this.props;
@@ -91,14 +94,14 @@ export default class ProposalSummary extends React.Component<IProps, IState> {
                         </th>
                         <td>
                           <span>{schemeRegistrar.schemeToRegister}</span>
-                          <img src="/assets/images/Icon/Copy-blue.svg" onClick={() => copyToClipboard(schemeRegistrar.schemeToRegister)} />
+                          <img src="/assets/images/Icon/Copy-blue.svg" onClick={this.copySchemeAddressOnClick(schemeRegistrar)} />
                         </td>
                       </tr>
                       <tr>
                         <th>Param Hash:</th>
                         <td>
                           <span>{schemeRegistrar.schemeToRegisterParamsHash.slice(0, 43)}</span>
-                          <img src="/assets/images/Icon/Copy-blue.svg" onClick={(): void => copyToClipboard(schemeRegistrar.schemeToRegisterParamsHash)} />
+                          <img src="/assets/images/Icon/Copy-blue.svg" onClick={this.copySchemeParamsHashOnClick(schemeRegistrar)} />
                         </td>
                       </tr>
                       <tr>

--- a/src/components/Proposal/Staking/StakeButtons.tsx
+++ b/src/components/Proposal/Staking/StakeButtons.tsx
@@ -72,7 +72,7 @@ class StakeButtons extends React.Component<IProps, IState> {
     this.setState({ showApproveModal: false });
   }
 
-  public closePreStakeModal = () => (_event: any): void => {
+  public closePreStakeModal = (_event: any): void => {
     this.setState({ showPreStakeModal: false });
   }
 
@@ -81,11 +81,11 @@ class StakeButtons extends React.Component<IProps, IState> {
     this.setState({ pendingPrediction: prediction, showPreStakeModal: true });
   }
 
-  public handleCancelPreApprove = () => async (_event: any): Promise<void> => {
+  public handleCancelPreApprove = async (_event: any): Promise<void> => {
     this.setState({ showApproveModal: false });
   }
 
-  public handleClickPreApprove = () => async (_event: any): Promise<void> => {
+  public handleClickPreApprove = async (_event: any): Promise<void> => {
     if (!await enableWalletProvider( { showNotification: this.props.showNotification })) { return; }
 
     const { approveStakingGens } = this.props;
@@ -142,8 +142,8 @@ class StakeButtons extends React.Component<IProps, IState> {
                 cost you GEN or commit you in any way to spending your GENs in the future.
               </p>
               <div className={css.preapproveButtonsWrapper}>
-                <button onClick={this.handleCancelPreApprove()} data-test-id="button-cancel">Cancel</button>
-                <button onClick={this.handleClickPreApprove()} data-test-id="button-preapprove">Preapprove</button>
+                <button onClick={this.handleCancelPreApprove} data-test-id="button-cancel">Cancel</button>
+                <button onClick={this.handleClickPreApprove} data-test-id="button-preapprove">Preapprove</button>
               </div>
             </div>
           </div>
@@ -215,7 +215,7 @@ class StakeButtons extends React.Component<IProps, IState> {
             actionType={pendingPrediction === VoteOptions.Yes ? ActionTypes.StakePass : ActionTypes.StakeFail}
             action={this.getStakeProposalAction(stakeProposal, proposal, pendingPrediction)}
             beneficiaryProfile={beneficiaryProfile}
-            closeAction={this.closePreStakeModal()}
+            closeAction={this.closePreStakeModal}
             currentAccountGens={currentAccountGens}
             dao={dao}
             proposal={proposal}

--- a/src/components/Proposal/Staking/StakeButtons.tsx
+++ b/src/components/Proposal/Staking/StakeButtons.tsx
@@ -72,7 +72,7 @@ class StakeButtons extends React.Component<IProps, IState> {
     this.setState({ showApproveModal: false });
   }
 
-  public closePreStakeModal = (_event: any): void => {
+  public closePreStakeModal = () => (_event: any): void => {
     this.setState({ showPreStakeModal: false });
   }
 
@@ -92,6 +92,9 @@ class StakeButtons extends React.Component<IProps, IState> {
     approveStakingGens(this.props.proposal.votingMachine);
     this.setState({ showApproveModal: false });
   }
+
+  private getStakeProposalAction = (stakeProposal: typeof arcActions.stakeProposal, proposal: IProposalState, pendingPrediction: number) => 
+    (amount: number) => { stakeProposal(proposal.dao.id, proposal.id, pendingPrediction, amount); };
 
   public render(): RenderOutput {
     const {
@@ -210,9 +213,9 @@ class StakeButtons extends React.Component<IProps, IState> {
         {showPreStakeModal ?
           <PreTransactionModal
             actionType={pendingPrediction === VoteOptions.Yes ? ActionTypes.StakePass : ActionTypes.StakeFail}
-            action={(amount: number) => { stakeProposal(proposal.dao.id, proposal.id, pendingPrediction, amount); }}
+            action={this.getStakeProposalAction(stakeProposal, proposal, pendingPrediction)}
             beneficiaryProfile={beneficiaryProfile}
-            closeAction={this.closePreStakeModal.bind(this)}
+            closeAction={this.closePreStakeModal()}
             currentAccountGens={currentAccountGens}
             dao={dao}
             proposal={proposal}

--- a/src/components/Proposal/Staking/StakeButtons.tsx
+++ b/src/components/Proposal/Staking/StakeButtons.tsx
@@ -62,7 +62,7 @@ class StakeButtons extends React.Component<IProps, IState> {
     };
   }
 
-  public showApprovalModal = () => async (_event: any): Promise<void> => {
+  public showApprovalModal = async (_event: any): Promise<void> => {
     if (!await enableWalletProvider({ showNotification: this.props.showNotification })) { return; }
 
     this.setState({ showApproveModal: true });
@@ -202,7 +202,7 @@ class StakeButtons extends React.Component<IProps, IState> {
       return (
         <div className={wrapperClass}>
           <div className={css.enablePredictions}>
-            <button onClick={this.showApprovalModal()} data-test-id="button-enable-predicting">Enable Predicting</button>
+            <button onClick={this.showApprovalModal} data-test-id="button-enable-predicting">Enable Predicting</button>
           </div>
         </div>
       );

--- a/src/components/Proposal/Voting/VoteButtons.tsx
+++ b/src/components/Proposal/Voting/VoteButtons.tsx
@@ -64,7 +64,7 @@ class VoteButtons extends React.Component<IProps, IState> {
   }
 
   private closePreVoteModal = () => (_event: any): void => { this.setState({ showPreVoteModal: false }); }
-  private handleVoteOnProposal = () => (): void => { this.props.voteOnProposal.bind(null, this.props.dao.address, this.props.proposal.id, this.state.currentVote);  };
+  private handleVoteOnProposal = () => (): void => { this.props.voteOnProposal(this.props.dao.address, this.props.proposal.id, this.state.currentVote);  };
 
   public render(): RenderOutput {
     const {
@@ -92,7 +92,7 @@ class VoteButtons extends React.Component<IProps, IState> {
      * only used when votingDisabled
      */
     const tipContent = 
-      ((this.props.currentVote === IProposalOutcome.Pass) || (this.props.currentVote === IProposalOutcome.Fail)) ?
+      ((currentVote === IProposalOutcome.Pass) || (currentVote === IProposalOutcome.Fail)) ?
         "Can't change your vote" :
         (currentAccountState && currentAccountState.reputation.eq(new BN(0))) ?
           "Voting requires reputation in " + dao.name :

--- a/src/components/Proposal/Voting/VoteButtons.tsx
+++ b/src/components/Proposal/Voting/VoteButtons.tsx
@@ -63,8 +63,8 @@ class VoteButtons extends React.Component<IProps, IState> {
     }
   }
 
-  private closePreVoteModal = () => (_event: any): void => { this.setState({ showPreVoteModal: false }); }
-  private handleVoteOnProposal = () => (): void => { this.props.voteOnProposal(this.props.dao.address, this.props.proposal.id, this.state.currentVote);  };
+  private closePreVoteModal = (_event: any): void => { this.setState({ showPreVoteModal: false }); }
+  private handleVoteOnProposal = (): void => { this.props.voteOnProposal(this.props.dao.address, this.props.proposal.id, this.state.currentVote);  };
 
   public render(): RenderOutput {
     const {
@@ -128,8 +128,8 @@ class VoteButtons extends React.Component<IProps, IState> {
         {this.state.showPreVoteModal ?
           <PreTransactionModal
             actionType={this.state.currentVote === IProposalOutcome.Pass ? ActionTypes.VoteUp : ActionTypes.VoteDown}
-            action={this.handleVoteOnProposal()}
-            closeAction={this.closePreVoteModal()}
+            action={this.handleVoteOnProposal}
+            closeAction={this.closePreVoteModal}
             currentAccount={currentAccountState}
             dao={dao}
             effectText={<span>Your influence: <strong><Reputation daoName={dao.name} totalReputation={dao.reputationTotalSupply} reputation={currentAccountState.reputation} /></strong></span>}

--- a/src/components/Proposal/Voting/VoteButtons.tsx
+++ b/src/components/Proposal/Voting/VoteButtons.tsx
@@ -65,25 +65,6 @@ class VoteButtons extends React.Component<IProps, IState> {
 
   private closePreVoteModal = () => (_event: any): void => { this.setState({ showPreVoteModal: false }); }
   private handleVoteOnProposal = () => (): void => { this.props.voteOnProposal.bind(null, this.props.dao.address, this.props.proposal.id, this.state.currentVote);  };
-  /**
-     * only invoked when votingDisabled
-     * @param vote
-     */
-  private tipContent = 
-  ((this.props.currentVote === IProposalOutcome.Pass) || (this.props.currentVote === IProposalOutcome.Fail)) ?
-    "Can't change your vote" :
-    (this.props.currentAccountState && this.props.currentAccountState.reputation.eq(new BN(0))) ?
-      "Voting requires reputation in " + this.props.dao.name :
-      this.props.proposal.stage === IProposalStage.ExpiredInQueue ||
-          (this.props.proposal.stage === IProposalStage.Boosted && this.props.expired) ||
-          (this.props.proposal.stage === IProposalStage.QuietEndingPeriod && this.props.expired)  ||
-          (this.props.proposal.stage === IProposalStage.Queued && this.props.expired) ?
-        "Can't vote on expired proposals" :
-        this.props.proposal.stage === IProposalStage.Executed ?
-          "Can't vote on executed proposals" : "";
-  
-
-
 
   public render(): RenderOutput {
     const {
@@ -96,6 +77,23 @@ class VoteButtons extends React.Component<IProps, IState> {
       dao,
       expired,
     } = this.props;
+
+    /**
+     * only invoked when votingDisabled
+     * @param vote
+     */
+    const tipContent = 
+      ((this.props.currentVote === IProposalOutcome.Pass) || (this.props.currentVote === IProposalOutcome.Fail)) ?
+        "Can't change your vote" :
+        (currentAccountState && currentAccountState.reputation.eq(new BN(0))) ?
+          "Voting requires reputation in " + dao.name :
+          proposal.stage === IProposalStage.ExpiredInQueue ||
+              (proposal.stage === IProposalStage.Boosted && expired) ||
+              (proposal.stage === IProposalStage.QuietEndingPeriod && expired)  ||
+              (proposal.stage === IProposalStage.Queued && expired) ?
+            "Can't vote on expired proposals" :
+            proposal.stage === IProposalStage.Executed ?
+              "Can't vote on executed proposals" : "";
 
     const votingDisabled = proposal.stage === IProposalStage.ExpiredInQueue ||
                             proposal.stage === IProposalStage.Executed ||
@@ -182,7 +180,7 @@ class VoteButtons extends React.Component<IProps, IState> {
                   </div>
                   :
                   <div className={css.votingDisabled}>
-                    <Tooltip overlay={this.tipContent}>
+                    <Tooltip overlay={tipContent}>
                       <span><img src="/assets/images/Icon/Alert-yellow-b.svg"/> Voting disabled</span>
                     </Tooltip>
                   </div>
@@ -208,7 +206,7 @@ class VoteButtons extends React.Component<IProps, IState> {
                 </div>
                 :
                 <div className={css.votingDisabled}>
-                  <Tooltip placement="bottom" overlay={this.tipContent}>
+                  <Tooltip placement="bottom" overlay={tipContent}>
                     <span>Voting disabled</span>
                   </Tooltip>
                 </div>

--- a/src/components/Proposal/Voting/VoteButtons.tsx
+++ b/src/components/Proposal/Voting/VoteButtons.tsx
@@ -78,9 +78,18 @@ class VoteButtons extends React.Component<IProps, IState> {
       expired,
     } = this.props;
 
+    const votingDisabled = proposal.stage === IProposalStage.ExpiredInQueue ||
+                            proposal.stage === IProposalStage.Executed ||
+                            (proposal.stage === IProposalStage.Queued && expired) ||
+                            (proposal.stage === IProposalStage.Boosted && expired) ||
+                            (proposal.stage === IProposalStage.QuietEndingPeriod && expired) ||
+                            (currentAccountState && currentAccountState.reputation.eq(new BN(0))) ||
+                            currentVote === IProposalOutcome.Pass ||
+                            currentVote === IProposalOutcome.Fail
+                            ;
+
     /**
-     * only invoked when votingDisabled
-     * @param vote
+     * only used when votingDisabled
      */
     const tipContent = 
       ((this.props.currentVote === IProposalOutcome.Pass) || (this.props.currentVote === IProposalOutcome.Fail)) ?
@@ -94,16 +103,6 @@ class VoteButtons extends React.Component<IProps, IState> {
             "Can't vote on expired proposals" :
             proposal.stage === IProposalStage.Executed ?
               "Can't vote on executed proposals" : "";
-
-    const votingDisabled = proposal.stage === IProposalStage.ExpiredInQueue ||
-                            proposal.stage === IProposalStage.Executed ||
-                            (proposal.stage === IProposalStage.Queued && expired) ||
-                            (proposal.stage === IProposalStage.Boosted && expired) ||
-                            (proposal.stage === IProposalStage.QuietEndingPeriod && expired) ||
-                            (currentAccountState && currentAccountState.reputation.eq(new BN(0))) ||
-                            currentVote === IProposalOutcome.Pass ||
-                            currentVote === IProposalOutcome.Fail
-                            ;
 
     const voteUpButtonClass = classNames({
       [css.votedFor]: currentVote === IProposalOutcome.Pass,

--- a/src/components/Redemptions/RedemptionsButton.tsx
+++ b/src/components/Redemptions/RedemptionsButton.tsx
@@ -48,7 +48,7 @@ class RedemptionsButton extends React.Component<IProps, null> {
     const { data: redeemableProposals } = this.props;
     const menu = <RedemptionsMenu
       redeemableProposals={redeemableProposals}
-      handleClose={this.closeMenu()}
+      handleClose={this.closeMenu}
     />;
     return <Tooltip
       ref={this.menu}
@@ -70,7 +70,7 @@ class RedemptionsButton extends React.Component<IProps, null> {
     </Tooltip>;
   }
 
-  private closeMenu = () => () => {
+  private closeMenu = () => {
     if (this.menu.current) {
       (this.menu.current as any).trigger.close();
     }

--- a/src/components/Redemptions/RedemptionsButton.tsx
+++ b/src/components/Redemptions/RedemptionsButton.tsx
@@ -48,7 +48,7 @@ class RedemptionsButton extends React.Component<IProps, null> {
     const { data: redeemableProposals } = this.props;
     const menu = <RedemptionsMenu
       redeemableProposals={redeemableProposals}
-      handleClose={this.closeMenu.bind(this)}
+      handleClose={this.closeMenu()}
     />;
     return <Tooltip
       ref={this.menu}
@@ -70,7 +70,7 @@ class RedemptionsButton extends React.Component<IProps, null> {
     </Tooltip>;
   }
 
-  private closeMenu() {
+  private closeMenu = () => () => {
     if (this.menu.current) {
       (this.menu.current as any).trigger.close();
     }

--- a/src/components/Redemptions/RedemptionsMenu.tsx
+++ b/src/components/Redemptions/RedemptionsMenu.tsx
@@ -75,7 +75,7 @@ class RedemptionsMenu extends React.Component<IProps, null> {
         </Link>
         <button
           className={css.redeemAllButton}
-          onClick={this.redeemAll()}
+          onClick={this.redeemAll}
           disabled={redeemableProposals.length === 0}
         >
           <img src="/assets/images/Icon/redeem.svg" />
@@ -85,7 +85,7 @@ class RedemptionsMenu extends React.Component<IProps, null> {
     </div>;
   }
 
-  private  redeemAll = () => async (): Promise<void> => {
+  private  redeemAll = async (): Promise<void> => {
     const {
       currentAccountAddress,
       data: redeemableProposals,

--- a/src/components/Redemptions/RedemptionsMenu.tsx
+++ b/src/components/Redemptions/RedemptionsMenu.tsx
@@ -75,7 +75,7 @@ class RedemptionsMenu extends React.Component<IProps, null> {
         </Link>
         <button
           className={css.redeemAllButton}
-          onClick={this.redeemAll.bind(this)}
+          onClick={this.redeemAll()}
           disabled={redeemableProposals.length === 0}
         >
           <img src="/assets/images/Icon/redeem.svg" />
@@ -85,7 +85,7 @@ class RedemptionsMenu extends React.Component<IProps, null> {
     </div>;
   }
 
-  private async redeemAll() {
+  private  redeemAll = () => async (): Promise<void> => {
     const {
       currentAccountAddress,
       data: redeemableProposals,

--- a/src/components/Redemptions/RedemptionsPage.tsx
+++ b/src/components/Redemptions/RedemptionsPage.tsx
@@ -65,7 +65,7 @@ class RedemptionsPage extends React.Component<IProps, null> {
             {proposals.length > 0 ?
               <button
                 className={css.redeemAllButton}
-                onClick={this.redeemAll.bind(this)}
+                onClick={this.redeemAll()}
               >
                 <img src="/assets/images/Icon/redeem.svg" />
                 Redeem all
@@ -89,7 +89,7 @@ class RedemptionsPage extends React.Component<IProps, null> {
     );
   }
 
-  private async redeemAll() {
+  private redeemAll = () => async (): Promise<void> => {
     const {
       currentAccountAddress,
       data: [, proposals],

--- a/src/components/Redemptions/RedemptionsPage.tsx
+++ b/src/components/Redemptions/RedemptionsPage.tsx
@@ -65,7 +65,7 @@ class RedemptionsPage extends React.Component<IProps, null> {
             {proposals.length > 0 ?
               <button
                 className={css.redeemAllButton}
-                onClick={this.redeemAll()}
+                onClick={this.redeemAll}
               >
                 <img src="/assets/images/Icon/redeem.svg" />
                 Redeem all
@@ -89,7 +89,7 @@ class RedemptionsPage extends React.Component<IProps, null> {
     );
   }
 
-  private redeemAll = () => async (): Promise<void> => {
+  private redeemAll = async (): Promise<void> => {
     const {
       currentAccountAddress,
       data: [, proposals],

--- a/src/components/Scheme/ReputationFromToken.tsx
+++ b/src/components/Scheme/ReputationFromToken.tsx
@@ -237,14 +237,12 @@ class ReputationFromToken extends React.Component<IProps, IState> {
             method: "post",
             data,
           });
-          console.log(response);
           if (response.data.status !== 200) {
             this.props.showNotification(NotificationStatus.Failure, `An error occurred on the transaction service: ${response.data.status}: ${response.data.message}`);
           } else {
             this.props.showNotification(NotificationStatus.Success, `You've successfully redeemed rep to ${values.accountAddress}`);
           }
         } catch(err) {
-          console.log(err.message);
           this.props.showNotification(NotificationStatus.Failure, `${err.message}}`);
         }
         // const tx = await contract.methods.redeemWithSignature(values.accountAddress.toLowerCase(), signatureType, signature).send(
@@ -261,6 +259,8 @@ class ReputationFromToken extends React.Component<IProps, IState> {
     }
     setSubmitting(false);
   }
+
+  private onSubmitClick = (setFieldValue: any) => ()=>{ setFieldValue("useTxSenderService",false); }
 
   public render(): RenderOutput {
     const { daoAvatarAddress, schemeState, currentAccountAddress } = this.props;
@@ -286,6 +286,7 @@ class ReputationFromToken extends React.Component<IProps, IState> {
               useTxSenderService: false,
             } as IFormValues}
 
+            // eslint-disable-next-line react/jsx-no-bind
             validate={(values: IFormValues): void => {
               const errors: any = {};
 
@@ -306,6 +307,7 @@ class ReputationFromToken extends React.Component<IProps, IState> {
 
             onSubmit={this.handleSubmit}
 
+            // eslint-disable-next-line react/jsx-no-bind
             render={({
               errors,
               touched,
@@ -332,9 +334,7 @@ class ReputationFromToken extends React.Component<IProps, IState> {
                 <div className={schemeCss.redemptionButton}>
                   <button type="submit"
                     disabled={false}
-                    onClick={(_e)=>{
-                      setFieldValue("useTxSenderService",false);
-                    }}
+                    onClick={this.onSubmitClick(setFieldValue)}
                   >
                     <img src="/assets/images/Icon/redeem.svg"/> Redeem
                   </button>
@@ -344,9 +344,7 @@ class ReputationFromToken extends React.Component<IProps, IState> {
                     <div>Or try our new experimental feature:</div>
                     <button type="submit"
                       disabled={false}
-                      onClick={(_e)=>{
-                        setFieldValue("useTxSenderService",true);
-                      }}
+                      onClick={this.onSubmitClick(setFieldValue)}
                     >
                       <img src="/assets/images/Icon/redeem.svg"/> Redeem w/o paying gas
                     </button>

--- a/src/components/Scheme/SchemeContainer.tsx
+++ b/src/components/Scheme/SchemeContainer.tsx
@@ -63,8 +63,11 @@ class SchemeContainer extends React.Component<IProps, null> {
     this.props.history.push(`/dao/${daoAvatarAddress}/scheme/${schemeId}/proposals/create/`);
   };
 
+  private schemeInfoPageHtml = () => (props: any) => <SchemeInfoPage {...props} daoAvatarAddress={this.props.daoAvatarAddress} scheme={this.props.data} />;
+  private schemeProposalsPageHtml = (isActive: boolean) => (props: any) => <SchemeProposalsPage {...props} isActive={isActive} currentAccountAddress={this.props.currentAccountAddress} scheme={this.props.data} />;
+
   public render(): RenderOutput {
-    const { currentAccountAddress, daoAvatarAddress, schemeId } = this.props;
+    const { daoAvatarAddress, schemeId } = this.props;
     const schemeState = this.props.data;
 
     if (schemeState.name === "ReputationFromToken") {
@@ -112,10 +115,10 @@ class SchemeContainer extends React.Component<IProps, null> {
 
         <Switch>
           <Route exact path="/dao/:daoAvatarAddress/scheme/:schemeId/info"
-            render={(props) => <SchemeInfoPage {...props} daoAvatarAddress={daoAvatarAddress} scheme={schemeState} />} />
+            render={this.schemeInfoPageHtml()} />
 
           <Route path="/dao/:daoAvatarAddress/scheme/:schemeId"
-            render={(props) => <SchemeProposalsPage {...props} isActive={isActive} currentAccountAddress={currentAccountAddress} scheme={schemeState} />} />
+            render={this.schemeProposalsPageHtml(isActive)} />
         </Switch>
       </div>
     );

--- a/src/components/Scheme/SchemeContainer.tsx
+++ b/src/components/Scheme/SchemeContainer.tsx
@@ -63,7 +63,7 @@ class SchemeContainer extends React.Component<IProps, null> {
     this.props.history.push(`/dao/${daoAvatarAddress}/scheme/${schemeId}/proposals/create/`);
   };
 
-  private schemeInfoPageHtml = () => (props: any) => <SchemeInfoPage {...props} daoAvatarAddress={this.props.daoAvatarAddress} scheme={this.props.data} />;
+  private schemeInfoPageHtml = (props: any) => <SchemeInfoPage {...props} daoAvatarAddress={this.props.daoAvatarAddress} scheme={this.props.data} />;
   private schemeProposalsPageHtml = (isActive: boolean) => (props: any) => <SchemeProposalsPage {...props} isActive={isActive} currentAccountAddress={this.props.currentAccountAddress} scheme={this.props.data} />;
 
   public render(): RenderOutput {
@@ -115,7 +115,7 @@ class SchemeContainer extends React.Component<IProps, null> {
 
         <Switch>
           <Route exact path="/dao/:daoAvatarAddress/scheme/:schemeId/info"
-            render={this.schemeInfoPageHtml()} />
+            render={this.schemeInfoPageHtml} />
 
           <Route path="/dao/:daoAvatarAddress/scheme/:schemeId"
             render={this.schemeProposalsPageHtml(isActive)} />

--- a/src/components/Shared/PreTransactionModal.tsx
+++ b/src/components/Shared/PreTransactionModal.tsx
@@ -79,7 +79,7 @@ class PreTransactionModal extends React.Component<IProps, IState> {
   }
 
   private stakeOnChange = () => (e: any) => this.setState({stakeAmount: Number(e.target.value)});
-  private ref = (input: any) => { this.stakeInput = input; };
+  private ref = () => (input: any) => { this.stakeInput = input; };
   private exchangeHtml = (item: any) => {
     return(
       <li key={item.name}>
@@ -286,7 +286,7 @@ class PreTransactionModal extends React.Component<IProps, IState> {
                           autoFocus
                           type="number"
                           min="1"
-                          ref={this.ref}
+                          ref={this.ref()}
                           className={css.predictionAmount}
                           onChange={this.stakeOnChange()}
                           placeholder="0"

--- a/src/components/Shared/PreTransactionModal.tsx
+++ b/src/components/Shared/PreTransactionModal.tsx
@@ -74,12 +74,12 @@ class PreTransactionModal extends React.Component<IProps, IState> {
     this.props.closeAction();
   }
 
-  public toggleInstructions = () => () => {
+  public toggleInstructions = () => {
     this.setState({ instructionsOpen: !this.state.instructionsOpen });
   }
 
-  private stakeOnChange = () => (e: any) => this.setState({stakeAmount: Number(e.target.value)});
-  private ref = () => (input: any) => { this.stakeInput = input; };
+  private stakeOnChange = (e: any) => this.setState({stakeAmount: Number(e.target.value)});
+  private ref = (input: any) => { this.stakeInput = input; };
   private exchangeHtml = (item: any) => {
     return(
       <li key={item.name}>
@@ -243,7 +243,7 @@ class PreTransactionModal extends React.Component<IProps, IState> {
               </div>
               {actionType !== ActionTypes.Redeem && actionType !== ActionTypes.Execute ?
                 <div className={classNames({[css.helpButton]: true, [css.open]: this.state.instructionsOpen})}>
-                  <button className={css.hover}  onClick={this.toggleInstructions()}>
+                  <button className={css.hover}  onClick={this.toggleInstructions}>
                     <b> &lt; Got it</b>
                     <span>x</span>
                     <span>?</span>
@@ -286,9 +286,9 @@ class PreTransactionModal extends React.Component<IProps, IState> {
                           autoFocus
                           type="number"
                           min="1"
-                          ref={this.ref()}
+                          ref={this.ref}
                           className={css.predictionAmount}
-                          onChange={this.stakeOnChange()}
+                          onChange={this.stakeOnChange}
                           placeholder="0"
                         />
                         <span className={css.genLabel + " " + css.genSymbol}>GEN</span>

--- a/src/components/Shared/PreTransactionModal.tsx
+++ b/src/components/Shared/PreTransactionModal.tsx
@@ -62,7 +62,7 @@ class PreTransactionModal extends React.Component<IProps, IState> {
     };
   }
 
-  private handleClickAction = () => async (): Promise<void> => {
+  private handleClickAction = async (): Promise<void> => {
     const { actionType, showNotification } = this.props;
     if (!await enableWalletProvider({ showNotification })) { return; }
 
@@ -358,14 +358,14 @@ class PreTransactionModal extends React.Component<IProps, IState> {
                       <button
                         className={classNames({[css.launchMetaMask]: true, [css.disabled]: true})}
                         disabled
-                        onClick={this.handleClickAction()}
+                        onClick={this.handleClickAction}
                         data-test-id="launch-metamask"
                       >
                         {transactionType}
                       </button>
                     </Tooltip>
                     :
-                    <button className={css.launchMetaMask} onClick={this.handleClickAction()} data-test-id="launch-metamask">
+                    <button className={css.launchMetaMask} onClick={this.handleClickAction} data-test-id="launch-metamask">
                       {transactionType}
                     </button>
                   }

--- a/src/components/Shared/PreTransactionModal.tsx
+++ b/src/components/Shared/PreTransactionModal.tsx
@@ -62,7 +62,7 @@ class PreTransactionModal extends React.Component<IProps, IState> {
     };
   }
 
-  public async handleClickAction() {
+  private handleClickAction = () => async (): Promise<void> => {
     const { actionType, showNotification } = this.props;
     if (!await enableWalletProvider({ showNotification })) { return; }
 
@@ -74,9 +74,22 @@ class PreTransactionModal extends React.Component<IProps, IState> {
     this.props.closeAction();
   }
 
-  public toggleInstructions() {
+  public toggleInstructions = () => () => {
     this.setState({ instructionsOpen: !this.state.instructionsOpen });
   }
+
+  private stakeOnChange = () => (e: any) => this.setState({stakeAmount: Number(e.target.value)});
+  private ref = (input: any) => { this.stakeInput = input; };
+  private exchangeHtml = (item: any) => {
+    return(
+      <li key={item.name}>
+        <a href={item.url} target="_blank" rel="noopener noreferrer">
+          <b><img src={item.logo}/></b>
+          <span>{item.name}</span>
+        </a>
+      </li>
+    );
+  };
 
   public render(): RenderOutput {
     const { actionType, beneficiaryProfile, currentAccount, currentAccountGens, dao, effectText, multiLineMsg, proposal, secondaryHeader } = this.props;
@@ -230,7 +243,7 @@ class PreTransactionModal extends React.Component<IProps, IState> {
               </div>
               {actionType !== ActionTypes.Redeem && actionType !== ActionTypes.Execute ?
                 <div className={classNames({[css.helpButton]: true, [css.open]: this.state.instructionsOpen})}>
-                  <button className={css.hover}  onClick={this.toggleInstructions.bind(this)}>
+                  <button className={css.hover}  onClick={this.toggleInstructions()}>
                     <b> &lt; Got it</b>
                     <span>x</span>
                     <span>?</span>
@@ -273,9 +286,9 @@ class PreTransactionModal extends React.Component<IProps, IState> {
                           autoFocus
                           type="number"
                           min="1"
-                          ref={(input) => { this.stakeInput = input; }}
+                          ref={this.ref}
                           className={css.predictionAmount}
-                          onChange={(e) => this.setState({stakeAmount: Number(e.target.value)})}
+                          onChange={this.stakeOnChange()}
                           placeholder="0"
                         />
                         <span className={css.genLabel + " " + css.genSymbol}>GEN</span>
@@ -286,16 +299,7 @@ class PreTransactionModal extends React.Component<IProps, IState> {
                             <ul>
                               <div className={css.diamond}></div>
                               {
-                                getExchangesList().map((item: any) => {
-                                  return(
-                                    <li key={item.name}>
-                                      <a href={item.url} target="_blank" rel="noopener noreferrer">
-                                        <b><img src={item.logo}/></b>
-                                        <span>{item.name}</span>
-                                      </a>
-                                    </li>
-                                  );
-                                })
+                                getExchangesList().map(this.exchangeHtml)
                               }
                             </ul>
                           </div>
@@ -354,14 +358,14 @@ class PreTransactionModal extends React.Component<IProps, IState> {
                       <button
                         className={classNames({[css.launchMetaMask]: true, [css.disabled]: true})}
                         disabled
-                        onClick={this.handleClickAction.bind(this)}
+                        onClick={this.handleClickAction()}
                         data-test-id="launch-metamask"
                       >
                         {transactionType}
                       </button>
                     </Tooltip>
                     :
-                    <button className={css.launchMetaMask} onClick={this.handleClickAction.bind(this)} data-test-id="launch-metamask">
+                    <button className={css.launchMetaMask} onClick={this.handleClickAction()} data-test-id="launch-metamask">
                       {transactionType}
                     </button>
                   }

--- a/src/layouts/AppContainer.tsx
+++ b/src/layouts/AppContainer.tsx
@@ -15,7 +15,7 @@ import { connect } from "react-redux";
 import { Route, Switch } from "react-router-dom";
 import { ModalContainer } from "react-router-modal";
 import { IRootState } from "reducers";
-import { dismissNotification, INotificationsState, NotificationStatus, showNotification } from "reducers/notifications";
+import { dismissNotification, INotificationsState, NotificationStatus, showNotification, INotification } from "reducers/notifications";
 import { getCachedAccount, cacheWeb3Info, uncacheWeb3Info, gotoReadonly, pollForAccountChanges } from "arc";
 import ErrorUncaught from "components/Errors/ErrorUncaught";
 import { sortedNotifications } from "../selectors/notifications";
@@ -116,10 +116,37 @@ class AppContainer extends React.Component<IProps, IState> {
     this.setState({ error: null, sentryEventId: null });
   }
 
+  private dismissNotif = (id: string) => () => this.props.dismissNotification(id);
+  private minimizeNotif = () => () => this.setState({notificationsMinimized: true});
+  private unminimizeNotif = () => () => this.setState({notificationsMinimized: false});
+  private headerHtml = ( props: any ): any => <Header {...props} />;
+
+  private sortedNotification = () => (notif: INotification): any => {
+    return <div key={notif.id}>
+      <Notification
+        title={(notif.title || notif.status).toUpperCase()}
+        status={
+          notif.status === NotificationStatus.Failure ?
+            NotificationViewStatus.Failure :
+            notif.status === NotificationStatus.Success ?
+              NotificationViewStatus.Success :
+              NotificationViewStatus.Pending
+        }
+        message={notif.message}
+        fullErrorMessage={notif.fullErrorMessage}
+        url={notif.url}
+        timestamp={notif.timestamp}
+        dismiss={this.dismissNotif(notif.id)}
+        showNotification={this.props.showNotification}
+        minimize={this.minimizeNotif()}
+      />
+    </div>; 
+  }
+              
+
   public render(): RenderOutput {
+    
     const {
-      dismissNotification,
-      showNotification,
       sortedNotifications,
     } = this.props;
 
@@ -139,13 +166,7 @@ class AppContainer extends React.Component<IProps, IState> {
           <BreadcrumbsItem to="/">Alchemy</BreadcrumbsItem>
 
           <div className={css.container}>
-            <Route path="/"
-            // eslint-disable react/jsx-no-bind
-              render={( props ): any => {
-                return <Header
-                  {...props} />;
-              }
-              } />
+            <Route path="/" render={this.headerHtml} />
 
             <Switch>
               <Route path="/dao/:daoAvatarAddress" component={DaoContainer} />
@@ -163,31 +184,9 @@ class AppContainer extends React.Component<IProps, IState> {
 
           <div className={css.pendingTransactions}>
             {this.state.notificationsMinimized ?
-              <MinimizedNotifications
-                notifications={sortedNotifications.length}
-                unminimize={() => this.setState({notificationsMinimized: false})}
-              /> :
-              sortedNotifications.map(({id, status, title, message, fullErrorMessage, timestamp, url}): any => (
-                <div key={id}>
-                  <Notification
-                    title={(title || status).toUpperCase()}
-                    status={
-                      status === NotificationStatus.Failure ?
-                        NotificationViewStatus.Failure :
-                        status === NotificationStatus.Success ?
-                          NotificationViewStatus.Success :
-                          NotificationViewStatus.Pending
-                    }
-                    message={message}
-                    fullErrorMessage={fullErrorMessage}
-                    url={url}
-                    timestamp={timestamp}
-                    dismiss={() => dismissNotification(id)}
-                    showNotification={showNotification}
-                    minimize={() => this.setState({notificationsMinimized: true})}
-                  />
-                </div>
-              ))
+              <MinimizedNotifications notifications={sortedNotifications.length} unminimize={this.unminimizeNotif()} />
+              :
+              sortedNotifications.map(this.sortedNotification())
             }
           </div>
           <div className={css.background}></div>

--- a/src/layouts/AppContainer.tsx
+++ b/src/layouts/AppContainer.tsx
@@ -121,7 +121,7 @@ class AppContainer extends React.Component<IProps, IState> {
   private unminimizeNotif = () => () => this.setState({notificationsMinimized: false});
   private headerHtml = ( props: any ): any => <Header {...props} />;
 
-  private sortedNotification = () => (notif: INotification): any => {
+  private notificationHtml = () => (notif: INotification): any => {
     return <div key={notif.id}>
       <Notification
         title={(notif.title || notif.status).toUpperCase()}
@@ -186,7 +186,7 @@ class AppContainer extends React.Component<IProps, IState> {
             {this.state.notificationsMinimized ?
               <MinimizedNotifications notifications={sortedNotifications.length} unminimize={this.unminimizeNotif()} />
               :
-              sortedNotifications.map(this.sortedNotification())
+              sortedNotifications.map(this.notificationHtml())
             }
           </div>
           <div className={css.background}></div>

--- a/src/layouts/AppContainer.tsx
+++ b/src/layouts/AppContainer.tsx
@@ -117,11 +117,11 @@ class AppContainer extends React.Component<IProps, IState> {
   }
 
   private dismissNotif = (id: string) => () => this.props.dismissNotification(id);
-  private minimizeNotif = () => () => this.setState({notificationsMinimized: true});
-  private unminimizeNotif = () => () => this.setState({notificationsMinimized: false});
+  private minimizeNotif = () => this.setState({notificationsMinimized: true});
+  private unminimizeNotif = () => this.setState({notificationsMinimized: false});
   private headerHtml = ( props: any ): any => <Header {...props} />;
 
-  private notificationHtml = () => (notif: INotification): any => {
+  private notificationHtml = (notif: INotification): any => {
     return <div key={notif.id}>
       <Notification
         title={(notif.title || notif.status).toUpperCase()}
@@ -138,7 +138,7 @@ class AppContainer extends React.Component<IProps, IState> {
         timestamp={notif.timestamp}
         dismiss={this.dismissNotif(notif.id)}
         showNotification={this.props.showNotification}
-        minimize={this.minimizeNotif()}
+        minimize={this.minimizeNotif}
       />
     </div>; 
   }
@@ -184,9 +184,9 @@ class AppContainer extends React.Component<IProps, IState> {
 
           <div className={css.pendingTransactions}>
             {this.state.notificationsMinimized ?
-              <MinimizedNotifications notifications={sortedNotifications.length} unminimize={this.unminimizeNotif()} />
+              <MinimizedNotifications notifications={sortedNotifications.length} unminimize={this.unminimizeNotif} />
               :
-              sortedNotifications.map(this.notificationHtml())
+              sortedNotifications.map(this.notificationHtml)
             }
           </div>
           <div className={css.background}></div>

--- a/src/layouts/Header.tsx
+++ b/src/layouts/Header.tsx
@@ -116,11 +116,11 @@ class Header extends React.Component<IProps, IStateProps> {
     await gotoReadonly(this.props.showNotification);
   }
 
-  private handleToggleMenu = () => (_event: any): void => {
+  private handleToggleMenu = (_event: any): void => {
     this.props.toggleMenu();
   }
 
-  private handleTrainingTooltipsEnabled = () => (event: any): void => {
+  private handleTrainingTooltipsEnabled = (event: any): void => {
     /**
      * maybe making this asynchronous can address reports of the button responding very slowly
      */
@@ -166,7 +166,7 @@ class Header extends React.Component<IProps, IStateProps> {
           [css.hasHamburger]: !!daoAvatarAddress,
         })}>
           { daoAvatarAddress ?
-            <div className={css.menuToggle} onClick={this.handleToggleMenu()}>
+            <div className={css.menuToggle} onClick={this.handleToggleMenu}>
               {this.props.menuOpen ?
                 <img src="/assets/images/Icon/Close.svg"/> :
                 <img src="/assets/images/Icon/Menu.svg"/>}
@@ -190,7 +190,7 @@ class Header extends React.Component<IProps, IStateProps> {
             <div className={css.toggleButton} ref={this.toggleDiv}>
               <Toggle
                 defaultChecked={trainingTooltipsOn}
-                onChange={this.handleTrainingTooltipsEnabled()}
+                onChange={this.handleTrainingTooltipsEnabled}
                 icons={{ checked: <img src='/assets/images/Icon/checked.svg'/>, unchecked: <img src='/assets/images/Icon/unchecked.svg'/> }}/>
             </div>
           </TrainingTooltip>

--- a/src/layouts/Header.tsx
+++ b/src/layouts/Header.tsx
@@ -145,6 +145,8 @@ class Header extends React.Component<IProps, IStateProps> {
     }
   }
 
+  private breadCrumbCompare = (a: any, b: any): number => a.weight ? a.weight - b.weight : a.to.length - b.to.length;
+
   public render(): RenderOutput {
     const {
       currentAccountProfile,
@@ -181,7 +183,7 @@ class Header extends React.Component<IProps, IStateProps> {
               separator={<b> &gt;   </b>}
               item={NavLink}
               finalItem={"b"}
-              compare={(a: any, b: any): number => a.weight ? a.weight - b.weight : a.to.length - b.to.length}
+              compare={this.breadCrumbCompare}
             />
           </div>
           <TrainingTooltip placement="left" overlay={"Show / hide tooltips on hover"}>

--- a/src/lib/util.ts
+++ b/src/lib/util.ts
@@ -533,7 +533,8 @@ export function roundUp(num: number, precision: number) {
 export function ethErrorHandler() {
   const returnValueOnError: any = null; // return this when there is an error
   return catchError((err: any) => {
-    console.log(`Error! ${err.message}`);
+    // eslint-disable-next-line no-console
+    console.error(err.message);
     return of(returnValueOnError);
   });
 }


### PR DESCRIPTION
This is in an effort to minimize spurious react component rendering by removing most of the uses of arrow and .bind functions  in `render`. 

Down to only 11 lint warnings.

But I don't honestly see any significant performance improvements.