### PR TITLE
[WIP] instantiate TrainingTooltips only when target is visible

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -22849,6 +22849,14 @@
         "react-lifecycles-compat": "^3.0.4"
       }
     },
+    "react-visibility-sensor": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/react-visibility-sensor/-/react-visibility-sensor-5.1.1.tgz",
+      "integrity": "sha512-cTUHqIK+zDYpeK19rzW6zF9YfT4486TIgizZW53wEZ+/GPBbK7cNS0EHyJVyHYacwFEvvHLEKfgJndbemWhB/w==",
+      "requires": {
+        "prop-types": "^15.7.2"
+      }
+    },
     "read-pkg": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-1.1.0.tgz",

--- a/package.json
+++ b/package.json
@@ -124,6 +124,7 @@
     "react-through": "^1.1.1",
     "react-toggle": "^4.1.1",
     "react-transition-group": "^2.5.1",
+    "react-visibility-sensor": "^5.1.1",
     "redux": "^4.0.4",
     "redux-devtools-extension": "^2.13.7",
     "redux-thunk": "2.2.0",

--- a/src/components/Proposal/ProposalCard.tsx
+++ b/src/components/Proposal/ProposalCard.tsx
@@ -9,6 +9,7 @@ import { Link } from "react-router-dom";
 import { closingTime } from "reducers/arcReducer";
 import TagsSelector from "components/Proposal/Create/SchemeForms/TagsSelector";
 import TrainingTooltip from "components/Shared/TrainingTooltip";
+import VisibilitySensor from "react-visibility-sensor";
 import ActionButton from "./ActionButton";
 import BoostAmount from "./Staking/BoostAmount";
 import StakeButtons from "./Staking/StakeButtons";
@@ -30,6 +31,10 @@ interface IExternalProps {
 type IProps = IExternalProps;
 
 export default class ProposalCard extends React.Component<IProps, null> {
+
+  constructor(props: IProps) {
+    super(props);
+  }
 
   public render(): RenderOutput {
 
@@ -82,51 +87,128 @@ export default class ProposalCard extends React.Component<IProps, null> {
           [css.voteControls]: true,
         });
 
-        return (
-          <div className={proposalClass + " clearfix"} data-test-id={"proposal-" + proposal.id}>
-            <div className={css.proposalInfo}>
-              <div className={css.cardTop + " clearfix"}>
-                <div className={css.timer}>
-                  <span className={css.content}>
-                    {!expired
-                      ? <Countdown toDate={closingTime(proposal)} detailView={false} overTime={proposal.stage === IProposalStage.QuietEndingPeriod && !expired} />
-                      : <span className={css.closedTime}>
-                        {proposal.stage === IProposalStage.Queued ? "Expired" :
-                          proposal.stage === IProposalStage.PreBoosted ? "Ready to Boost" :
-                            "Closed"}&nbsp;
-                        {closingTime(proposal).format("MMM D, YYYY")}
-                      </span>
-                    }
-                  </span>
+        return <VisibilitySensor key={proposal.id} scrollCheck resizeCheck intervalCheck={false}>
+          {({isVisible}) =>
+            <div className={proposalClass + " clearfix"} data-test-id={"proposal-" + proposal.id}>
+              <div className={css.proposalInfo}>
+                <div className={css.cardTop + " clearfix"}>
+                  <div className={css.timer}>
+                    <span className={css.content}>
+                      {!expired
+                        ? <Countdown toDate={closingTime(proposal)} detailView={false} overTime={proposal.stage === IProposalStage.QuietEndingPeriod && !expired} />
+                        : <span className={css.closedTime}>
+                          {proposal.stage === IProposalStage.Queued ? "Expired" :
+                            proposal.stage === IProposalStage.PreBoosted ? "Ready to Boost" :
+                              "Closed"}&nbsp;
+                          {closingTime(proposal).format("MMM D, YYYY")}
+                        </span>
+                      }
+                    </span>
+                  </div>
+
+                  <div className={css.actionButton}>
+                    <ActionButton
+                      currentAccountAddress={currentAccountAddress}
+                      daoState={daoState}
+                      daoEthBalance={daoEthBalance}
+                      proposalState={proposal}
+                      rewards={rewards}
+                      expired={expired}
+                    />
+
+                    <div className={css.contextMenu} data-test-id="proposalContextMenu">
+                      <div className={css.menuIcon}>
+                        <img src="/assets/images/Icon/Context-menu.svg"/>
+                      </div>
+                      <div className={css.menu}>
+                        <VoteButtons
+                          currentAccountAddress={currentAccountAddress}
+                          currentAccountState={member}
+                          currentVote={currentAccountVote}
+                          dao={daoState}
+                          expired={expired}
+                          proposal={proposal}
+                          contextMenu/>
+
+                        <StakeButtons
+                          beneficiaryProfile={beneficiaryProfile}
+                          contextMenu
+                          currentAccountAddress={currentAccountAddress}
+                          currentAccountGens={currentAccountGenBalance}
+                          currentAccountGenStakingAllowance={currentAccountGenAllowance}
+                          dao={daoState}
+                          expired={expired}
+                          proposal={proposal}
+                          stakes={stakes}
+                        />
+                      </div>
+                    </div>
+                  </div>
+                </div>
+                <div className={css.createdBy}>
+                  <AccountPopup accountAddress={proposal.proposer} daoState={daoState} detailView={false} />
+                  <AccountProfileName accountAddress={proposal.proposer} accountProfile={creatorProfile} daoAvatarAddress={daoState.address} detailView={false} />
+                </div>
+                <div className={css.description}>
+                  {proposal.description}
                 </div>
 
-                <div className={css.actionButton}>
-                  <ActionButton
-                    currentAccountAddress={currentAccountAddress}
-                    daoState={daoState}
-                    daoEthBalance={daoEthBalance}
-                    proposalState={proposal}
-                    rewards={rewards}
-                    expired={expired}
-                  />
+                <h3>
+                  <Link className={css.detailLink} to={"/dao/" + daoState.address + "/proposal/" + proposal.id} data-test-id="proposal-title">
+                    <span>{humanProposalTitle(proposal)}</span>
+                    <img src="/assets/images/Icon/Open.svg" />
+                  </Link>
+                </h3>
 
-                  <div className={css.contextMenu} data-test-id="proposalContextMenu">
-                    <div className={css.menuIcon}>
-                      <img src="/assets/images/Icon/Context-menu.svg"/>
+                { tags && tags.length ? <div className={css.tagsContainer}>
+                  <TagsSelector readOnly tags={tags}></TagsSelector>
+                </div> : "" }
+
+                <div className={css.summary}>
+                  <ProposalSummary proposal={proposal} dao={daoState} beneficiaryProfile={beneficiaryProfile} detailView={false} />
+                </div>
+
+              </div>
+
+              <div className={css.proposalActions + " clearfix"}>
+                <TrainingTooltip hide={!isVisible} placement="topLeft" overlay={"Percentage of voting power currently voting for and against"}>
+                  <div className={voteWrapperClass}>
+                    <div className={voteControls + " clearfix"}>
+                      <div className={css.voteDivider}>
+                        <VoteGraph size={40} proposal={proposal} />
+                      </div>
+
+                      <VoteBreakdown
+                        currentAccountAddress={currentAccountAddress}
+                        currentAccountState={member}
+                        currentVote={currentAccountVote}
+                        daoState={daoState}
+                        proposal={proposal}
+                        detailView={false} />
                     </div>
-                    <div className={css.menu}>
+
+                    <div className={css.voteButtons}>
                       <VoteButtons
                         currentAccountAddress={currentAccountAddress}
                         currentAccountState={member}
                         currentVote={currentAccountVote}
                         dao={daoState}
                         expired={expired}
-                        proposal={proposal}
-                        contextMenu/>
+                        proposal={proposal} />
+                    </div>
+                  </div>
+                </TrainingTooltip>
 
+                <TrainingTooltip hide={!isVisible} placement="topRight" overlay={"GEN tokens staked to predict the proposal will pass or fail"}>
+                  <div className={css.predictions}>
+                    <StakeGraph
+                      proposal={proposal}
+                    />
+                    <BoostAmount proposal={proposal} />
+
+                    <div className={css.predictionButtons}>
                       <StakeButtons
                         beneficiaryProfile={beneficiaryProfile}
-                        contextMenu
                         currentAccountAddress={currentAccountAddress}
                         currentAccountGens={currentAccountGenBalance}
                         currentAccountGenStakingAllowance={currentAccountGenAllowance}
@@ -137,86 +219,11 @@ export default class ProposalCard extends React.Component<IProps, null> {
                       />
                     </div>
                   </div>
-                </div>
+                </TrainingTooltip>
               </div>
-              <div className={css.createdBy}>
-                <AccountPopup accountAddress={proposal.proposer} daoState={daoState} detailView={false} />
-                <AccountProfileName accountAddress={proposal.proposer} accountProfile={creatorProfile} daoAvatarAddress={daoState.address} detailView={false} />
-              </div>
-              <div className={css.description}>
-                {proposal.description}
-              </div>
-
-              <h3>
-                <Link className={css.detailLink} to={"/dao/" + daoState.address + "/proposal/" + proposal.id} data-test-id="proposal-title">
-                  <span>{humanProposalTitle(proposal)}</span>
-                  <img src="/assets/images/Icon/Open.svg" />
-                </Link>
-              </h3>
-
-              { tags && tags.length ? <div className={css.tagsContainer}>
-                <TagsSelector readOnly tags={tags}></TagsSelector>
-              </div> : "" }
-
-              <div className={css.summary}>
-                <ProposalSummary proposal={proposal} dao={daoState} beneficiaryProfile={beneficiaryProfile} detailView={false} />
-              </div>
-
             </div>
-
-            <div className={css.proposalActions + " clearfix"}>
-              <TrainingTooltip placement="topLeft" overlay={"Percentage of voting power currently voting for and against"}>
-                <div className={voteWrapperClass}>
-                  <div className={voteControls + " clearfix"}>
-                    <div className={css.voteDivider}>
-                      <VoteGraph size={40} proposal={proposal} />
-                    </div>
-
-                    <VoteBreakdown
-                      currentAccountAddress={currentAccountAddress}
-                      currentAccountState={member}
-                      currentVote={currentAccountVote}
-                      daoState={daoState}
-                      proposal={proposal}
-                      detailView={false} />
-                  </div>
-
-                  <div className={css.voteButtons}>
-                    <VoteButtons
-                      currentAccountAddress={currentAccountAddress}
-                      currentAccountState={member}
-                      currentVote={currentAccountVote}
-                      dao={daoState}
-                      expired={expired}
-                      proposal={proposal} />
-                  </div>
-                </div>
-              </TrainingTooltip>
-
-              <TrainingTooltip placement="topRight" overlay={"GEN tokens staked to predict the proposal will pass or fail"}>
-                <div className={css.predictions}>
-                  <StakeGraph
-                    proposal={proposal}
-                  />
-                  <BoostAmount proposal={proposal} />
-
-                  <div className={css.predictionButtons}>
-                    <StakeButtons
-                      beneficiaryProfile={beneficiaryProfile}
-                      currentAccountAddress={currentAccountAddress}
-                      currentAccountGens={currentAccountGenBalance}
-                      currentAccountGenStakingAllowance={currentAccountGenAllowance}
-                      dao={daoState}
-                      expired={expired}
-                      proposal={proposal}
-                      stakes={stakes}
-                    />
-                  </div>
-                </div>
-              </TrainingTooltip>
-            </div>
-          </div>
-        );
+          }
+        </VisibilitySensor>;
       }
       }
     </ProposalData>;

--- a/src/components/Proposal/ProposalCard.tsx
+++ b/src/components/Proposal/ProposalCard.tsx
@@ -9,7 +9,6 @@ import { Link } from "react-router-dom";
 import { closingTime } from "reducers/arcReducer";
 import TagsSelector from "components/Proposal/Create/SchemeForms/TagsSelector";
 import TrainingTooltip from "components/Shared/TrainingTooltip";
-import VisibilitySensor from "react-visibility-sensor";
 import ActionButton from "./ActionButton";
 import BoostAmount from "./Staking/BoostAmount";
 import StakeButtons from "./Staking/StakeButtons";
@@ -87,147 +86,139 @@ export default class ProposalCard extends React.Component<IProps, null> {
           [css.voteControls]: true,
         });
 
-        const votingHtml = <div className={voteWrapperClass}>
-          <div className={voteControls + " clearfix"}>
-            <div className={css.voteDivider}>
-              <VoteGraph size={40} proposal={proposal} />
-            </div>
-
-            <VoteBreakdown
-              currentAccountAddress={currentAccountAddress}
-              currentAccountState={member}
-              currentVote={currentAccountVote}
-              daoState={daoState}
-              proposal={proposal}
-              detailView={false} />
-          </div>
-
-          <div className={css.voteButtons}>
-            <VoteButtons
-              currentAccountAddress={currentAccountAddress}
-              currentAccountState={member}
-              currentVote={currentAccountVote}
-              dao={daoState}
-              expired={expired}
-              proposal={proposal} />
-          </div>
-        </div>;
-
-        const stakingHtml = <div className={css.predictions}>
-          <StakeGraph
-            proposal={proposal}
-          />
-          <BoostAmount proposal={proposal} />
-
-          <div className={css.predictionButtons}>
-            <StakeButtons
-              beneficiaryProfile={beneficiaryProfile}
-              currentAccountAddress={currentAccountAddress}
-              currentAccountGens={currentAccountGenBalance}
-              currentAccountGenStakingAllowance={currentAccountGenAllowance}
-              dao={daoState}
-              expired={expired}
-              proposal={proposal}
-              stakes={stakes}
-            />
-          </div>
-        </div>;
-
-        return <VisibilitySensor key={proposal.id} scrollCheck resizeCheck intervalCheck={false}>
-          {({isVisible}) =>
-            <div className={proposalClass + " clearfix"} data-test-id={"proposal-" + proposal.id}>
-              <div className={css.proposalInfo}>
-                <div className={css.cardTop + " clearfix"}>
-                  <div className={css.timer}>
-                    <span className={css.content}>
-                      {!expired
-                        ? <Countdown toDate={closingTime(proposal)} detailView={false} overTime={proposal.stage === IProposalStage.QuietEndingPeriod && !expired} />
-                        : <span className={css.closedTime}>
-                          {proposal.stage === IProposalStage.Queued ? "Expired" :
-                            proposal.stage === IProposalStage.PreBoosted ? "Ready to Boost" :
-                              "Closed"}&nbsp;
-                          {closingTime(proposal).format("MMM D, YYYY")}
-                        </span>
-                      }
+        return <div className={proposalClass + " clearfix"} data-test-id={"proposal-" + proposal.id}>
+          <div className={css.proposalInfo}>
+            <div className={css.cardTop + " clearfix"}>
+              <div className={css.timer}>
+                <span className={css.content}>
+                  {!expired
+                    ? <Countdown toDate={closingTime(proposal)} detailView={false} overTime={proposal.stage === IProposalStage.QuietEndingPeriod && !expired} />
+                    : <span className={css.closedTime}>
+                      {proposal.stage === IProposalStage.Queued ? "Expired" :
+                        proposal.stage === IProposalStage.PreBoosted ? "Ready to Boost" :
+                          "Closed"}&nbsp;
+                      {closingTime(proposal).format("MMM D, YYYY")}
                     </span>
-                  </div>
-
-                  <div className={css.actionButton}>
-                    <ActionButton
-                      currentAccountAddress={currentAccountAddress}
-                      daoState={daoState}
-                      daoEthBalance={daoEthBalance}
-                      proposalState={proposal}
-                      rewards={rewards}
-                      expired={expired}
-                    />
-
-                    <div className={css.contextMenu} data-test-id="proposalContextMenu">
-                      <div className={css.menuIcon}>
-                        <img src="/assets/images/Icon/Context-menu.svg"/>
-                      </div>
-                      <div className={css.menu}>
-                        <VoteButtons
-                          currentAccountAddress={currentAccountAddress}
-                          currentAccountState={member}
-                          currentVote={currentAccountVote}
-                          dao={daoState}
-                          expired={expired}
-                          proposal={proposal}
-                          contextMenu/>
-
-                        <StakeButtons
-                          beneficiaryProfile={beneficiaryProfile}
-                          contextMenu
-                          currentAccountAddress={currentAccountAddress}
-                          currentAccountGens={currentAccountGenBalance}
-                          currentAccountGenStakingAllowance={currentAccountGenAllowance}
-                          dao={daoState}
-                          expired={expired}
-                          proposal={proposal}
-                          stakes={stakes}
-                        />
-                      </div>
-                    </div>
-                  </div>
-                </div>
-                <div className={css.createdBy}>
-                  <AccountPopup accountAddress={proposal.proposer} daoState={daoState} detailView={false} />
-                  <AccountProfileName accountAddress={proposal.proposer} accountProfile={creatorProfile} daoAvatarAddress={daoState.address} detailView={false} />
-                </div>
-                <div className={css.description}>
-                  {proposal.description}
-                </div>
-
-                <h3>
-                  <Link className={css.detailLink} to={"/dao/" + daoState.address + "/proposal/" + proposal.id} data-test-id="proposal-title">
-                    <span>{humanProposalTitle(proposal)}</span>
-                    <img src="/assets/images/Icon/Open.svg" />
-                  </Link>
-                </h3>
-
-                { tags && tags.length ? <div className={css.tagsContainer}>
-                  <TagsSelector readOnly tags={tags}></TagsSelector>
-                </div> : "" }
-
-                <div className={css.summary}>
-                  <ProposalSummary proposal={proposal} dao={daoState} beneficiaryProfile={beneficiaryProfile} detailView={false} />
-                </div>
-
+                  }
+                </span>
               </div>
 
-              <div className={css.proposalActions + " clearfix"}>
-                { isVisible ? (<TrainingTooltip placement="topLeft" overlay={"Percentage of voting power currently voting for and against"}>
-                  {votingHtml}
-                </TrainingTooltip>) : votingHtml }
+              <div className={css.actionButton}>
+                <ActionButton
+                  currentAccountAddress={currentAccountAddress}
+                  daoState={daoState}
+                  daoEthBalance={daoEthBalance}
+                  proposalState={proposal}
+                  rewards={rewards}
+                  expired={expired}
+                />
 
-                { isVisible ? (<TrainingTooltip placement="topRight" overlay={"GEN tokens staked to predict the proposal will pass or fail"}>
-                  {stakingHtml}
-                </TrainingTooltip>) : stakingHtml }
+                <div className={css.contextMenu} data-test-id="proposalContextMenu">
+                  <div className={css.menuIcon}>
+                    <img src="/assets/images/Icon/Context-menu.svg"/>
+                  </div>
+                  <div className={css.menu}>
+                    <VoteButtons
+                      currentAccountAddress={currentAccountAddress}
+                      currentAccountState={member}
+                      currentVote={currentAccountVote}
+                      dao={daoState}
+                      expired={expired}
+                      proposal={proposal}
+                      contextMenu/>
+
+                    <StakeButtons
+                      beneficiaryProfile={beneficiaryProfile}
+                      contextMenu
+                      currentAccountAddress={currentAccountAddress}
+                      currentAccountGens={currentAccountGenBalance}
+                      currentAccountGenStakingAllowance={currentAccountGenAllowance}
+                      dao={daoState}
+                      expired={expired}
+                      proposal={proposal}
+                      stakes={stakes}
+                    />
+                  </div>
+                </div>
               </div>
             </div>
-          }
-        </VisibilitySensor>;
+            <div className={css.createdBy}>
+              <AccountPopup accountAddress={proposal.proposer} daoState={daoState} detailView={false} />
+              <AccountProfileName accountAddress={proposal.proposer} accountProfile={creatorProfile} daoAvatarAddress={daoState.address} detailView={false} />
+            </div>
+            <div className={css.description}>
+              {proposal.description}
+            </div>
+
+            <h3>
+              <Link className={css.detailLink} to={"/dao/" + daoState.address + "/proposal/" + proposal.id} data-test-id="proposal-title">
+                <span>{humanProposalTitle(proposal)}</span>
+                <img src="/assets/images/Icon/Open.svg" />
+              </Link>
+            </h3>
+
+            { tags && tags.length ? <div className={css.tagsContainer}>
+              <TagsSelector readOnly tags={tags}></TagsSelector>
+            </div> : "" }
+
+            <div className={css.summary}>
+              <ProposalSummary proposal={proposal} dao={daoState} beneficiaryProfile={beneficiaryProfile} detailView={false} />
+            </div>
+
+          </div>
+
+          <div className={css.proposalActions + " clearfix"}>
+            <TrainingTooltip placement="topLeft" overlay={"Percentage of voting power currently voting for and against"}>
+              <div className={voteWrapperClass}>
+                <div className={voteControls + " clearfix"}>
+                  <div className={css.voteDivider}>
+                    <VoteGraph size={40} proposal={proposal} />
+                  </div>
+
+                  <VoteBreakdown
+                    currentAccountAddress={currentAccountAddress}
+                    currentAccountState={member}
+                    currentVote={currentAccountVote}
+                    daoState={daoState}
+                    proposal={proposal}
+                    detailView={false} />
+                </div>
+
+                <div className={css.voteButtons}>
+                  <VoteButtons
+                    currentAccountAddress={currentAccountAddress}
+                    currentAccountState={member}
+                    currentVote={currentAccountVote}
+                    dao={daoState}
+                    expired={expired}
+                    proposal={proposal} />
+                </div>
+              </div>
+            </TrainingTooltip>
+
+            <TrainingTooltip placement="topRight" overlay={"GEN tokens staked to predict the proposal will pass or fail"}>
+              <div className={css.predictions}>
+                <StakeGraph
+                  proposal={proposal}
+                />
+                <BoostAmount proposal={proposal} />
+
+                <div className={css.predictionButtons}>
+                  <StakeButtons
+                    beneficiaryProfile={beneficiaryProfile}
+                    currentAccountAddress={currentAccountAddress}
+                    currentAccountGens={currentAccountGenBalance}
+                    currentAccountGenStakingAllowance={currentAccountGenAllowance}
+                    dao={daoState}
+                    expired={expired}
+                    proposal={proposal}
+                    stakes={stakes}
+                  />
+                </div>
+              </div>
+            </TrainingTooltip>
+          </div>
+        </div>;
       }
       }
     </ProposalData>;

--- a/src/components/Proposal/ProposalCard.tsx
+++ b/src/components/Proposal/ProposalCard.tsx
@@ -31,10 +31,6 @@ type IProps = IExternalProps;
 
 export default class ProposalCard extends React.Component<IProps, null> {
 
-  constructor(props: IProps) {
-    super(props);
-  }
-
   public render(): RenderOutput {
 
     const {
@@ -86,50 +82,127 @@ export default class ProposalCard extends React.Component<IProps, null> {
           [css.voteControls]: true,
         });
 
-        return <div className={proposalClass + " clearfix"} data-test-id={"proposal-" + proposal.id}>
-          <div className={css.proposalInfo}>
-            <div className={css.cardTop + " clearfix"}>
-              <div className={css.timer}>
-                <span className={css.content}>
-                  {!expired
-                    ? <Countdown toDate={closingTime(proposal)} detailView={false} overTime={proposal.stage === IProposalStage.QuietEndingPeriod && !expired} />
-                    : <span className={css.closedTime}>
-                      {proposal.stage === IProposalStage.Queued ? "Expired" :
-                        proposal.stage === IProposalStage.PreBoosted ? "Ready to Boost" :
-                          "Closed"}&nbsp;
-                      {closingTime(proposal).format("MMM D, YYYY")}
-                    </span>
-                  }
-                </span>
+        return (
+          <div className={proposalClass + " clearfix"} data-test-id={"proposal-" + proposal.id}>
+            <div className={css.proposalInfo}>
+              <div className={css.cardTop + " clearfix"}>
+                <div className={css.timer}>
+                  <span className={css.content}>
+                    {!expired
+                      ? <Countdown toDate={closingTime(proposal)} detailView={false} overTime={proposal.stage === IProposalStage.QuietEndingPeriod && !expired} />
+                      : <span className={css.closedTime}>
+                        {proposal.stage === IProposalStage.Queued ? "Expired" :
+                          proposal.stage === IProposalStage.PreBoosted ? "Ready to Boost" :
+                            "Closed"}&nbsp;
+                        {closingTime(proposal).format("MMM D, YYYY")}
+                      </span>
+                    }
+                  </span>
+                </div>
+
+                <div className={css.actionButton}>
+                  <ActionButton
+                    currentAccountAddress={currentAccountAddress}
+                    daoState={daoState}
+                    daoEthBalance={daoEthBalance}
+                    proposalState={proposal}
+                    rewards={rewards}
+                    expired={expired}
+                  />
+
+                  <div className={css.contextMenu} data-test-id="proposalContextMenu">
+                    <div className={css.menuIcon}>
+                      <img src="/assets/images/Icon/Context-menu.svg"/>
+                    </div>
+                    <div className={css.menu}>
+                      <VoteButtons
+                        currentAccountAddress={currentAccountAddress}
+                        currentAccountState={member}
+                        currentVote={currentAccountVote}
+                        dao={daoState}
+                        expired={expired}
+                        proposal={proposal}
+                        contextMenu/>
+
+                      <StakeButtons
+                        beneficiaryProfile={beneficiaryProfile}
+                        contextMenu
+                        currentAccountAddress={currentAccountAddress}
+                        currentAccountGens={currentAccountGenBalance}
+                        currentAccountGenStakingAllowance={currentAccountGenAllowance}
+                        dao={daoState}
+                        expired={expired}
+                        proposal={proposal}
+                        stakes={stakes}
+                      />
+                    </div>
+                  </div>
+                </div>
+              </div>
+              <div className={css.createdBy}>
+                <AccountPopup accountAddress={proposal.proposer} daoState={daoState} detailView={false} />
+                <AccountProfileName accountAddress={proposal.proposer} accountProfile={creatorProfile} daoAvatarAddress={daoState.address} detailView={false} />
+              </div>
+              <div className={css.description}>
+                {proposal.description}
               </div>
 
-              <div className={css.actionButton}>
-                <ActionButton
-                  currentAccountAddress={currentAccountAddress}
-                  daoState={daoState}
-                  daoEthBalance={daoEthBalance}
-                  proposalState={proposal}
-                  rewards={rewards}
-                  expired={expired}
-                />
+              <h3>
+                <Link className={css.detailLink} to={"/dao/" + daoState.address + "/proposal/" + proposal.id} data-test-id="proposal-title">
+                  <span>{humanProposalTitle(proposal)}</span>
+                  <img src="/assets/images/Icon/Open.svg" />
+                </Link>
+              </h3>
 
-                <div className={css.contextMenu} data-test-id="proposalContextMenu">
-                  <div className={css.menuIcon}>
-                    <img src="/assets/images/Icon/Context-menu.svg"/>
+              { tags && tags.length ? <div className={css.tagsContainer}>
+                <TagsSelector readOnly tags={tags}></TagsSelector>
+              </div> : "" }
+
+              <div className={css.summary}>
+                <ProposalSummary proposal={proposal} dao={daoState} beneficiaryProfile={beneficiaryProfile} detailView={false} />
+              </div>
+
+            </div>
+
+            <div className={css.proposalActions + " clearfix"}>
+              <TrainingTooltip placement="topLeft" overlay={"Percentage of voting power currently voting for and against"}>
+                <div className={voteWrapperClass}>
+                  <div className={voteControls + " clearfix"}>
+                    <div className={css.voteDivider}>
+                      <VoteGraph size={40} proposal={proposal} />
+                    </div>
+
+                    <VoteBreakdown
+                      currentAccountAddress={currentAccountAddress}
+                      currentAccountState={member}
+                      currentVote={currentAccountVote}
+                      daoState={daoState}
+                      proposal={proposal}
+                      detailView={false} />
                   </div>
-                  <div className={css.menu}>
+
+                  <div className={css.voteButtons}>
                     <VoteButtons
                       currentAccountAddress={currentAccountAddress}
                       currentAccountState={member}
                       currentVote={currentAccountVote}
                       dao={daoState}
                       expired={expired}
-                      proposal={proposal}
-                      contextMenu/>
+                      proposal={proposal} />
+                  </div>
+                </div>
+              </TrainingTooltip>
 
+              <TrainingTooltip placement="topRight" overlay={"GEN tokens staked to predict the proposal will pass or fail"}>
+                <div className={css.predictions}>
+                  <StakeGraph
+                    proposal={proposal}
+                  />
+                  <BoostAmount proposal={proposal} />
+
+                  <div className={css.predictionButtons}>
                     <StakeButtons
                       beneficiaryProfile={beneficiaryProfile}
-                      contextMenu
                       currentAccountAddress={currentAccountAddress}
                       currentAccountGens={currentAccountGenBalance}
                       currentAccountGenStakingAllowance={currentAccountGenAllowance}
@@ -140,85 +213,10 @@ export default class ProposalCard extends React.Component<IProps, null> {
                     />
                   </div>
                 </div>
-              </div>
+              </TrainingTooltip>
             </div>
-            <div className={css.createdBy}>
-              <AccountPopup accountAddress={proposal.proposer} daoState={daoState} detailView={false} />
-              <AccountProfileName accountAddress={proposal.proposer} accountProfile={creatorProfile} daoAvatarAddress={daoState.address} detailView={false} />
-            </div>
-            <div className={css.description}>
-              {proposal.description}
-            </div>
-
-            <h3>
-              <Link className={css.detailLink} to={"/dao/" + daoState.address + "/proposal/" + proposal.id} data-test-id="proposal-title">
-                <span>{humanProposalTitle(proposal)}</span>
-                <img src="/assets/images/Icon/Open.svg" />
-              </Link>
-            </h3>
-
-            { tags && tags.length ? <div className={css.tagsContainer}>
-              <TagsSelector readOnly tags={tags}></TagsSelector>
-            </div> : "" }
-
-            <div className={css.summary}>
-              <ProposalSummary proposal={proposal} dao={daoState} beneficiaryProfile={beneficiaryProfile} detailView={false} />
-            </div>
-
           </div>
-
-          <div className={css.proposalActions + " clearfix"}>
-            <TrainingTooltip placement="topLeft" overlay={"Percentage of voting power currently voting for and against"}>
-              <div className={voteWrapperClass}>
-                <div className={voteControls + " clearfix"}>
-                  <div className={css.voteDivider}>
-                    <VoteGraph size={40} proposal={proposal} />
-                  </div>
-
-                  <VoteBreakdown
-                    currentAccountAddress={currentAccountAddress}
-                    currentAccountState={member}
-                    currentVote={currentAccountVote}
-                    daoState={daoState}
-                    proposal={proposal}
-                    detailView={false} />
-                </div>
-
-                <div className={css.voteButtons}>
-                  <VoteButtons
-                    currentAccountAddress={currentAccountAddress}
-                    currentAccountState={member}
-                    currentVote={currentAccountVote}
-                    dao={daoState}
-                    expired={expired}
-                    proposal={proposal} />
-                </div>
-              </div>
-            </TrainingTooltip>
-
-            <TrainingTooltip placement="topRight" overlay={"GEN tokens staked to predict the proposal will pass or fail"}>
-              <div className={css.predictions}>
-                <StakeGraph
-                  proposal={proposal}
-                />
-                <BoostAmount proposal={proposal} />
-
-                <div className={css.predictionButtons}>
-                  <StakeButtons
-                    beneficiaryProfile={beneficiaryProfile}
-                    currentAccountAddress={currentAccountAddress}
-                    currentAccountGens={currentAccountGenBalance}
-                    currentAccountGenStakingAllowance={currentAccountGenAllowance}
-                    dao={daoState}
-                    expired={expired}
-                    proposal={proposal}
-                    stakes={stakes}
-                  />
-                </div>
-              </div>
-            </TrainingTooltip>
-          </div>
-        </div>;
+        );
       }
       }
     </ProposalData>;

--- a/src/components/Proposal/ProposalCard.tsx
+++ b/src/components/Proposal/ProposalCard.tsx
@@ -87,6 +87,52 @@ export default class ProposalCard extends React.Component<IProps, null> {
           [css.voteControls]: true,
         });
 
+        const votingHtml = <div className={voteWrapperClass}>
+          <div className={voteControls + " clearfix"}>
+            <div className={css.voteDivider}>
+              <VoteGraph size={40} proposal={proposal} />
+            </div>
+
+            <VoteBreakdown
+              currentAccountAddress={currentAccountAddress}
+              currentAccountState={member}
+              currentVote={currentAccountVote}
+              daoState={daoState}
+              proposal={proposal}
+              detailView={false} />
+          </div>
+
+          <div className={css.voteButtons}>
+            <VoteButtons
+              currentAccountAddress={currentAccountAddress}
+              currentAccountState={member}
+              currentVote={currentAccountVote}
+              dao={daoState}
+              expired={expired}
+              proposal={proposal} />
+          </div>
+        </div>;
+
+        const stakingHtml = <div className={css.predictions}>
+          <StakeGraph
+            proposal={proposal}
+          />
+          <BoostAmount proposal={proposal} />
+
+          <div className={css.predictionButtons}>
+            <StakeButtons
+              beneficiaryProfile={beneficiaryProfile}
+              currentAccountAddress={currentAccountAddress}
+              currentAccountGens={currentAccountGenBalance}
+              currentAccountGenStakingAllowance={currentAccountGenAllowance}
+              dao={daoState}
+              expired={expired}
+              proposal={proposal}
+              stakes={stakes}
+            />
+          </div>
+        </div>;
+
         return <VisibilitySensor key={proposal.id} scrollCheck resizeCheck intervalCheck={false}>
           {({isVisible}) =>
             <div className={proposalClass + " clearfix"} data-test-id={"proposal-" + proposal.id}>
@@ -171,55 +217,13 @@ export default class ProposalCard extends React.Component<IProps, null> {
               </div>
 
               <div className={css.proposalActions + " clearfix"}>
-                <TrainingTooltip hide={!isVisible} placement="topLeft" overlay={"Percentage of voting power currently voting for and against"}>
-                  <div className={voteWrapperClass}>
-                    <div className={voteControls + " clearfix"}>
-                      <div className={css.voteDivider}>
-                        <VoteGraph size={40} proposal={proposal} />
-                      </div>
+                { isVisible ? (<TrainingTooltip placement="topLeft" overlay={"Percentage of voting power currently voting for and against"}>
+                  {votingHtml}
+                </TrainingTooltip>) : votingHtml }
 
-                      <VoteBreakdown
-                        currentAccountAddress={currentAccountAddress}
-                        currentAccountState={member}
-                        currentVote={currentAccountVote}
-                        daoState={daoState}
-                        proposal={proposal}
-                        detailView={false} />
-                    </div>
-
-                    <div className={css.voteButtons}>
-                      <VoteButtons
-                        currentAccountAddress={currentAccountAddress}
-                        currentAccountState={member}
-                        currentVote={currentAccountVote}
-                        dao={daoState}
-                        expired={expired}
-                        proposal={proposal} />
-                    </div>
-                  </div>
-                </TrainingTooltip>
-
-                <TrainingTooltip hide={!isVisible} placement="topRight" overlay={"GEN tokens staked to predict the proposal will pass or fail"}>
-                  <div className={css.predictions}>
-                    <StakeGraph
-                      proposal={proposal}
-                    />
-                    <BoostAmount proposal={proposal} />
-
-                    <div className={css.predictionButtons}>
-                      <StakeButtons
-                        beneficiaryProfile={beneficiaryProfile}
-                        currentAccountAddress={currentAccountAddress}
-                        currentAccountGens={currentAccountGenBalance}
-                        currentAccountGenStakingAllowance={currentAccountGenAllowance}
-                        dao={daoState}
-                        expired={expired}
-                        proposal={proposal}
-                        stakes={stakes}
-                      />
-                    </div>
-                  </div>
-                </TrainingTooltip>
+                { isVisible ? (<TrainingTooltip placement="topRight" overlay={"GEN tokens staked to predict the proposal will pass or fail"}>
+                  {stakingHtml}
+                </TrainingTooltip>) : stakingHtml }
               </div>
             </div>
           }

--- a/src/components/Shared/TrainingTooltip.tsx
+++ b/src/components/Shared/TrainingTooltip.tsx
@@ -15,7 +15,7 @@ interface IStateProps {
 }
 
 export interface IExternalProps extends RCTooltip.Props {
-
+  hide?: boolean;
 }
 
 type IProps = IExternalProps & IAppStateProps;
@@ -68,12 +68,13 @@ class TrainingToolip extends React.Component<IProps, IStateProps> {
     }
 
     return (
-      <Tooltip ref={this.tooltip} {...this.props}
-        prefixCls="rc-trainingtooltip"
-        trigger={this.props.enableHover ? ["hover"] : []}
-      >
-        {this.props.children}
-      </Tooltip>
+      this.props.hide ? "" :
+        <Tooltip ref={this.tooltip} {...this.props}
+          prefixCls="rc-trainingtooltip"
+          trigger={this.props.enableHover ? ["hover"] : []}
+        >
+          {this.props.children}
+        </Tooltip>
     );
   }
 }

--- a/src/layouts/Header.tsx
+++ b/src/layouts/Header.tsx
@@ -184,7 +184,7 @@ class Header extends React.Component<IProps, IStateProps> {
               compare={(a: any, b: any): number => a.weight ? a.weight - b.weight : a.to.length - b.to.length}
             />
           </div>
-          <TrainingTooltip placement="left" overlay={"Show / hide tooltips on hover"}>
+          <TrainingTooltip placement="left" alwaysAvailable overlay={"Show / hide tooltips on hover"}>
             <div className={css.toggleButton} ref={this.toggleDiv}>
               <Toggle
                 defaultChecked={trainingTooltipsOn}


### PR DESCRIPTION
uses react-visibility-sensor to enable us to instantiate TrainingTooltips only when the target html is visible.  This modestly speeds up the display of tooltips on the scheme proposals page when there are a lot of proposals.

**Note** I plan to submit another PR that will do no more that limit proposal card tooltips to the first card, visible or not.  We can choose which of these we want.