### PR TITLE
update DAO total reputation supply when it changes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,11 +1,11 @@
 ### template
   - Features Added
   - Bugs Fixed
-    - update DAO total rep when it changes, so rep percentages remain correct
 
 ## Next release
   - Features Added
   - Bugs Fixed
+    - update DAO total rep when it changes, so rep percentages remain correct
 
 ### 2019-11-12
   - Features added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ### template
   - Features Added
   - Bugs Fixed
+    - update DAO total rep when it changes, so rep percentages remain correct
 
 ## Next release
   - Features Added

--- a/src/components/Account/AccountProfilePage.tsx
+++ b/src/components/Account/AccountProfilePage.tsx
@@ -1,5 +1,5 @@
 import { promisify } from "util";
-import { IDAOState, IMemberState } from "@daostack/client";
+import { IDAOState, IMemberState, DAO } from "@daostack/client";
 
 import BN = require("bn.js");
 import * as profileActions from "actions/profilesActions";
@@ -302,9 +302,15 @@ const SubscribedAccountProfilePage = withSubscription({
     const queryValues = queryString.parse(props.location.search);
     const daoAvatarAddress = queryValues.daoAvatarAddress as string;
     const accountAddress = props.match.params.accountAddress;
+    let dao: DAO;
+    if (daoAvatarAddress) {
+      dao = arc.dao(daoAvatarAddress);
+    }
+
     return combineLatest(
-      daoAvatarAddress ? arc.dao(daoAvatarAddress).state() : of(null),
-      daoAvatarAddress ? arc.dao(daoAvatarAddress).member(accountAddress).state() : of(null),
+      // subscribe if only to to get DAO reputation supply updates
+      daoAvatarAddress ? dao.state( {subscribe: true}) : of(null),
+      daoAvatarAddress ? dao.member(accountAddress).state() : of(null),
       arc.ethBalance(accountAddress)
         .pipe(ethErrorHandler()),
       arc.GENToken().balanceOf(accountAddress)

--- a/src/components/Dao/DaoContainer.tsx
+++ b/src/components/Dao/DaoContainer.tsx
@@ -122,7 +122,7 @@ const SubscribedDaoContainer = withSubscription({
   createObservable: (props: IExternalProps) => {
     const arc = getArc(); // TODO: maybe we pass in the arc context from withSubscription instead of creating one every time?
     const daoAddress = props.match.params.daoAvatarAddress;
-    return arc.dao(daoAddress).state();
+    return arc.dao(daoAddress).state({ subscribe: true} );
   },
 });
 

--- a/src/components/Dao/DaoContainer.tsx
+++ b/src/components/Dao/DaoContainer.tsx
@@ -80,7 +80,7 @@ class DaoContainer extends React.Component<IProps, null> {
           </div>
           <Switch>
             <Route exact path="/dao/:daoAvatarAddress/history"
-              render={(props) => <DaoHistoryPage {...props} currentAccountAddress={currentAccountAddress} />} />
+              render={(props) => <DaoHistoryPage {...props} daoState={daoState} currentAccountAddress={currentAccountAddress} />} />
             <Route exact path="/dao/:daoAvatarAddress/members"
               render={(props) => <DaoMembersPage {...props} daoState={daoState} />} />
             <Route exact path="/dao/:daoAvatarAddress/discussion"

--- a/src/components/Dao/DaoContainer.tsx
+++ b/src/components/Dao/DaoContainer.tsx
@@ -99,7 +99,7 @@ class DaoContainer extends React.Component<IProps, null> {
             <Route path="/dao/:daoAvatarAddress/scheme/:schemeId"
               render={(props) => <SchemeContainer {...props} daoState={daoState} currentAccountAddress={currentAccountAddress} />} />
 
-            <Route path="/dao/:daoAvatarAddress" render={(props) => <DaoSchemesPage {...props} />} />
+            <Route path="/dao/:daoAvatarAddress" render={(props) => <DaoSchemesPage {...props} daoState={daoState} />} />
           </Switch>
 
           <ModalRoute
@@ -122,7 +122,7 @@ const SubscribedDaoContainer = withSubscription({
   createObservable: (props: IExternalProps) => {
     const arc = getArc(); // TODO: maybe we pass in the arc context from withSubscription instead of creating one every time?
     const daoAddress = props.match.params.daoAvatarAddress;
-    return arc.dao(daoAddress).state({ subscribe: true} );
+    return arc.dao(daoAddress).state({ subscribe: true, fetchAllData: true } );
   },
 });
 

--- a/src/components/Dao/DaoContainer.tsx
+++ b/src/components/Dao/DaoContainer.tsx
@@ -60,7 +60,7 @@ class DaoContainer extends React.Component<IProps, null> {
     this.props.getProfilesForAllAccounts();
   }
 
-  private daoHistoryRoute = (routeProps: any) => <DaoHistoryPage {...routeProps} currentAccountAddress={this.props.currentAccountAddress} />;
+  private daoHistoryRoute = (routeProps: any) => <DaoHistoryPage {...routeProps} daoState={this.props.data} currentAccountAddress={this.props.currentAccountAddress} />;
   private daoMembersRoute = (routeProps: any) => <DaoMembersPage {...routeProps} daoState={this.props.data} />;
   private daoDiscussionRoute = (routeProps: any) => <DaoDiscussionPage {...routeProps} dao={this.props.data} />;
   private daoProposalRoute = (routeProps: any) =>
@@ -71,7 +71,7 @@ class DaoContainer extends React.Component<IProps, null> {
     />;
 
   private schemeRoute = (routeProps: any) => <SchemeContainer {...routeProps} daoState={this.props.data} currentAccountAddress={this.props.currentAccountAddress} />;
-  private daoSchemesRoute = (routeProps: any) => <DaoSchemesPage {...routeProps} />;
+  private daoSchemesRoute = (routeProps: any) => <DaoSchemesPage {...routeProps} daoState={this.props.data} />;
   private modalRoute = (route: any) => `/dao/${route.params.daoAvatarAddress}/scheme/${route.params.schemeId}/`;
 
   public render(): RenderOutput {

--- a/src/components/Dao/DaoHistoryPage.tsx
+++ b/src/components/Dao/DaoHistoryPage.tsx
@@ -8,7 +8,6 @@ import { BreadcrumbsItem } from "react-breadcrumbs-dynamic";
 import * as InfiniteScroll from "react-infinite-scroll-component";
 import { RouteComponentProps } from "react-router-dom";
 import * as Sticky from "react-stickynode";
-import { combineLatest } from "rxjs";
 import { first } from "rxjs/operators";
 import ProposalHistoryRow from "../Proposal/ProposalHistoryRow";
 import * as css from "./Dao.scss";
@@ -17,26 +16,26 @@ const PAGE_SIZE = 50;
 
 interface IExternalProps extends RouteComponentProps<any> {
   currentAccountAddress: Address;
+  daoState: IDAOState;
 }
 
-type SubscriptionData = [Proposal[], IDAOState];
+type SubscriptionData = Proposal[];
 type IProps = IExternalProps & ISubscriptionProps<SubscriptionData>;
 
 class DaoHistoryPage extends React.Component<IProps, null> {
 
   public render(): RenderOutput {
-    const { data, hasMoreToLoad, fetchMore } = this.props;
+    const { data, hasMoreToLoad, fetchMore, daoState, currentAccountAddress } = this.props;
 
-    const [proposals, dao] = data;
-    const { currentAccountAddress } = this.props;
+    const proposals = data;
 
     const proposalsHTML = proposals.map((proposal: Proposal) => {
-      return (<ProposalHistoryRow key={"proposal_" + proposal.id} proposal={proposal} daoState={dao} currentAccountAddress={currentAccountAddress}/>);
+      return (<ProposalHistoryRow key={"proposal_" + proposal.id} proposal={proposal} daoState={daoState} currentAccountAddress={currentAccountAddress}/>);
     });
 
     return(
       <div>
-        <BreadcrumbsItem to={"/dao/" + dao.address + "/history"}>History</BreadcrumbsItem>
+        <BreadcrumbsItem to={"/dao/" + daoState.address + "/history"}>History</BreadcrumbsItem>
 
         <Sticky enabled top={50} innerZ={10000}>
           <div className={css.daoHistoryHeader}>
@@ -87,12 +86,11 @@ export default withSubscription({
   loadingComponent: <div className={css.loading}><Loading/></div>,
   errorComponent: (props) => <div>{ props.error.message }</div>,
 
-  checkForUpdate: (oldProps, newProps) => { return oldProps.match.params.daoAvatarAddress !== newProps.match.params.daoAvatarAddress; },
+  checkForUpdate: [],
 
   createObservable: async (props: IExternalProps) => {
     const arc = getArc();
-    const daoAvatarAddress = props.match.params.daoAvatarAddress;
-    const dao = arc.dao(daoAvatarAddress);
+    const dao = props.daoState.dao;
 
     // this query will fetch al data we need before rendering the page, so we avoid hitting the server
     // with all separate queries for votes and stakes and stuff...
@@ -134,33 +132,6 @@ export default withSubscription({
       ${Stake.fragments.StakeFields}
     `;
     await arc.getObservable(prefetchQuery, { subscribe: true }).pipe(first()).toPromise();
-    return combineLatest(
-      dao.proposals({
-        where: {
-          // eslint-disable-next-line @typescript-eslint/camelcase
-          stage_in: [IProposalStage.ExpiredInQueue, IProposalStage.Executed, IProposalStage.Queued],
-          // eslint-disable-next-line @typescript-eslint/camelcase
-          closingAt_lte: Math.floor(new Date().getTime() / 1000),
-        },
-        orderBy: "closingAt",
-        orderDirection: "desc",
-        first: PAGE_SIZE,
-        skip: 0,
-      },
-      { fetchAllData: true } // get and subscribe to all data, so that subcomponents do nto have to send separate queries
-      ),
-      dao.state()
-    );
-
-  },
-
-  // used for hacky pagination tracking
-  pageSize: PAGE_SIZE,
-
-  getFetchMoreObservable: (props: IExternalProps, data: SubscriptionData) => {
-    const arc = getArc();
-    const daoAvatarAddress = props.match.params.daoAvatarAddress;
-    const dao = arc.dao(daoAvatarAddress);
     return dao.proposals({
       where: {
         // eslint-disable-next-line @typescript-eslint/camelcase
@@ -171,13 +142,28 @@ export default withSubscription({
       orderBy: "closingAt",
       orderDirection: "desc",
       first: PAGE_SIZE,
-      skip: data[0].length,
-    },
-    { fetchAllData: true } // get and subscribe to all data, so that subcomponents do nto have to send separate queries
+      skip: 0,
+    }, { fetchAllData: true } // get and subscribe to all data, so that subcomponents do nto have to send separate queries
     );
   },
 
-  fetchMoreCombine: (prevState: SubscriptionData, newData: Proposal[]) => {
-    return [prevState[0].concat(newData), prevState[1]];
+  // used for hacky pagination tracking
+  pageSize: PAGE_SIZE,
+
+  getFetchMoreObservable: (props: IExternalProps, data: SubscriptionData) => {
+    const dao = props.daoState.dao;
+    return dao.proposals({
+      where: {
+        // eslint-disable-next-line @typescript-eslint/camelcase
+        stage_in: [IProposalStage.ExpiredInQueue, IProposalStage.Executed, IProposalStage.Queued],
+        // eslint-disable-next-line @typescript-eslint/camelcase
+        closingAt_lte: Math.floor(new Date().getTime() / 1000),
+      },
+      orderBy: "closingAt",
+      orderDirection: "desc",
+      first: PAGE_SIZE,
+      skip: data.length,
+    }, { fetchAllData: true } // get and subscribe to all data, so that subcomponents do nto have to send separate queries
+    );
   },
 });

--- a/src/components/Dao/DaoMember.tsx
+++ b/src/components/Dao/DaoMember.tsx
@@ -1,3 +1,4 @@
+import BN = require("bn.js");
 import { IDAOState, IMemberState, Member } from "@daostack/client";
 import AccountImage from "components/Account/AccountImage";
 import AccountProfileName from "components/Account/AccountProfileName";
@@ -13,12 +14,13 @@ interface IProps extends ISubscriptionProps<IMemberState> {
   dao: IDAOState;
   member: Member;
   profile: IProfileState;
+  daoTotalReputation: BN;
 }
 
 class DaoMember extends React.Component<IProps, null> {
 
   public render(): RenderOutput {
-    const { dao, profile } = this.props;
+    const { dao, profile, daoTotalReputation } = this.props;
     const memberState = this.props.data;
 
     return (
@@ -49,7 +51,7 @@ class DaoMember extends React.Component<IProps, null> {
               <td className={css.memberReputation}>
                 <span className={css.reputationAmount}>{fromWei(memberState.reputation).toLocaleString(undefined, {minimumFractionDigits: 0, maximumFractionDigits: 2})}</span>
                 <div className={css.reputationAmounts}>
-                  (<Reputation daoName={dao.name} totalReputation={dao.reputationTotalSupply} reputation={memberState.reputation}/>)
+                  (<Reputation daoName={dao.name} totalReputation={daoTotalReputation} reputation={memberState.reputation}/>)
                 </div>
               </td>
               <td className={css.memberSocial}>

--- a/src/components/Dao/DaoMembersPage.tsx
+++ b/src/components/Dao/DaoMembersPage.tsx
@@ -10,7 +10,6 @@ import * as Sticky from "react-stickynode";
 import { IRootState } from "reducers";
 import { IProfilesState } from "reducers/profilesReducer";
 
-import { combineLatest } from "rxjs";
 import DaoMember from "./DaoMember";
 import * as css from "./Dao.scss";
 
@@ -22,7 +21,7 @@ interface IStateProps {
   profiles: IProfilesState;
 }
 
-type IProps = IExternalProps & IStateProps & ISubscriptionProps<[Member[]]>;
+type IProps = IExternalProps & IStateProps & ISubscriptionProps<Member[]>;
 
 const mapStateToProps = (state: IRootState, ownProps: IExternalProps): IExternalProps & IStateProps => {
   return {
@@ -38,7 +37,7 @@ class DaoMembersPage extends React.Component<IProps, null> {
   public render(): RenderOutput {
     const { data } = this.props;
 
-    const members = data[0];
+    const members = data;
     const daoTotalReputation = this.props.daoState.reputationTotalSupply;
     const { daoState, profiles } = this.props;
 
@@ -90,29 +89,25 @@ const SubscribedDaoMembersPage = withSubscription({
   createObservable: async (props: IExternalProps) => {
     const dao = props.daoState.dao;
 
-    return combineLatest(
-      dao.members({
-        orderBy: "balance",
-        orderDirection: "desc",
-        first: PAGE_SIZE,
-        skip: 0,
-      })
-    );
+    return dao.members({
+      orderBy: "balance",
+      orderDirection: "desc",
+      first: PAGE_SIZE,
+      skip: 0,
+    });
   },
 
   // used for hacky pagination tracking
   pageSize: PAGE_SIZE,
 
-  getFetchMoreObservable: (props: IExternalProps, data: [Member[]]) => {
+  getFetchMoreObservable: (props: IExternalProps, data: Member[]) => {
     const dao = props.daoState.dao;
-    return combineLatest(
-      dao.members({
-        orderBy: "balance",
-        orderDirection: "desc",
-        first: PAGE_SIZE,
-        skip: data.length,
-      })
-    );
+    return dao.members({
+      orderBy: "balance",
+      orderDirection: "desc",
+      first: PAGE_SIZE,
+      skip: data.length,
+    });
   },
 });
 

--- a/src/components/Proposal/ProposalCard.tsx
+++ b/src/components/Proposal/ProposalCard.tsx
@@ -44,7 +44,7 @@ export default class ProposalCard extends React.Component<IProps, null> {
       proposal,
     } = this.props;
 
-    return <ProposalData currentAccountAddress={currentAccountAddress} dao={daoState} proposalId={proposal.id}>
+    return <ProposalData currentAccountAddress={currentAccountAddress} daoState={daoState} proposalId={proposal.id}>
       { props => {
         const {
           beneficiaryProfile,

--- a/src/components/Proposal/ProposalData.tsx
+++ b/src/components/Proposal/ProposalData.tsx
@@ -17,7 +17,7 @@ import * as css from "./ProposalCard.scss";
 
 interface IExternalProps {
   currentAccountAddress: Address;
-  dao: IDAOState;
+  daoState: IDAOState;
   proposalId: string;
   children(props: IInjectedProposalProps): JSX.Element;
 }
@@ -111,8 +111,8 @@ export default withSubscription({
 
   createObservable: async (props) => {
     const arc = getArc();
-    const { currentAccountAddress, dao, proposalId } = props;
-    const arcDao = arc.dao(dao.address);
+    const { currentAccountAddress, daoState, proposalId } = props;
+    const arcDao = daoState.dao;
     const proposal = arc.proposal(proposalId);
     await proposal.fetchStaticState();
     const spender = proposal.staticState.votingMachine;

--- a/src/components/Proposal/ProposalDetailsPage.tsx
+++ b/src/components/Proposal/ProposalDetailsPage.tsx
@@ -72,7 +72,7 @@ export default class ProposalDetailsPage extends React.Component<IProps, IState>
   public render(): RenderOutput {
     const { currentAccountAddress, daoState, proposalId } = this.props;
 
-    return <ProposalData currentAccountAddress={currentAccountAddress} dao={daoState} proposalId={proposalId}>
+    return <ProposalData currentAccountAddress={currentAccountAddress} daoState={daoState} proposalId={proposalId}>
       { props => {
         const {
           beneficiaryProfile,

--- a/src/components/Redemptions/RedemptionsMenu.tsx
+++ b/src/components/Redemptions/RedemptionsMenu.tsx
@@ -198,7 +198,8 @@ const SubscribedMenuItemContent = withSubscription({
     const rewards = proposal.proposal.rewards({ where: { beneficiary: currentAccountAddress }})
       .pipe(map((rewards: Reward[]): Reward => rewards.length === 1 && rewards[0] || null))
       .pipe(mergeMap(((reward: Reward): Observable<IRewardState> => reward ? reward.state() : of(null))));
-    return combineLatest(dao.state(), ethBalance, rewards);
+    // subscribe to dao to get DAO reputation supply updates
+    return combineLatest(dao.state( { subscribe: true }), ethBalance, rewards);
   },
 });
 

--- a/src/components/Scheme/SchemeContainer.tsx
+++ b/src/components/Scheme/SchemeContainer.tsx
@@ -30,7 +30,6 @@ interface IExternalProps extends RouteComponentProps<any> {
 }
 
 interface IStateProps {
-  daoAvatarAddress: Address;
   schemeId: Address;
 }
 
@@ -41,7 +40,6 @@ const mapStateToProps = (_state: IRootState, ownProps: IExternalProps): IExterna
 
   return {
     ...ownProps,
-    daoAvatarAddress: match.params.daoAvatarAddress,
     schemeId: match.params.schemeId,
   };
 };
@@ -53,7 +51,8 @@ const mapDispatchToProps = {
 class SchemeContainer extends React.Component<IProps, null> {
 
   public handleNewProposal = async (e: any): Promise<void> => {
-    const { daoAvatarAddress, schemeId, showNotification } = this.props;
+    const { schemeId, showNotification, daoState } = this.props;
+    const daoAvatarAddress = daoState.address;
     e.preventDefault();
 
     e.preventDefault();
@@ -64,7 +63,8 @@ class SchemeContainer extends React.Component<IProps, null> {
   };
 
   public render(): RenderOutput {
-    const { currentAccountAddress, daoAvatarAddress, schemeId } = this.props;
+    const { currentAccountAddress, schemeId, daoState } = this.props;
+    const daoAvatarAddress = daoState.address;
     const schemeState = this.props.data;
 
     if (schemeState.name === "ReputationFromToken") {
@@ -112,10 +112,10 @@ class SchemeContainer extends React.Component<IProps, null> {
 
         <Switch>
           <Route exact path="/dao/:daoAvatarAddress/scheme/:schemeId/info"
-            render={(props) => <SchemeInfoPage {...props} daoAvatarAddress={daoAvatarAddress} scheme={schemeState} />} />
+            render={(props) => <SchemeInfoPage {...props} scheme={schemeState}  daoState={daoState} />} />
 
           <Route path="/dao/:daoAvatarAddress/scheme/:schemeId"
-            render={(props) => <SchemeProposalsPage {...props} isActive={isActive} currentAccountAddress={currentAccountAddress} scheme={schemeState} />} />
+            render={(props) => <SchemeProposalsPage {...props} isActive={isActive} currentAccountAddress={currentAccountAddress} scheme={schemeState} daoState={daoState} />} />
         </Switch>
       </div>
     );

--- a/src/components/Scheme/SchemeContainer.tsx
+++ b/src/components/Scheme/SchemeContainer.tsx
@@ -62,8 +62,8 @@ class SchemeContainer extends React.Component<IProps, null> {
     this.props.history.push(`/dao/${daoAvatarAddress}/scheme/${schemeId}/proposals/create/`);
   };
 
-  private schemeInfoPageHtml = (props: any) => <SchemeInfoPage {...props} daoAvatarAddress={this.props.daoAvatarAddress} scheme={this.props.data} />;
-  private schemeProposalsPageHtml = (isActive: boolean) => (props: any) => <SchemeProposalsPage {...props} isActive={isActive} currentAccountAddress={this.props.currentAccountAddress} scheme={this.props.data} />;
+  private schemeInfoPageHtml = (props: any) => <SchemeInfoPage {...props} scheme={this.props.data} />;
+  private schemeProposalsPageHtml = (isActive: boolean, daoState: IDAOState) => (props: any) => <SchemeProposalsPage {...props} isActive={isActive} daoState={daoState} currentAccountAddress={this.props.currentAccountAddress} scheme={this.props.data} />;
 
   public render(): RenderOutput {
     const { schemeId, daoState } = this.props;
@@ -118,7 +118,7 @@ class SchemeContainer extends React.Component<IProps, null> {
             render={this.schemeInfoPageHtml} />
 
           <Route path="/dao/:daoAvatarAddress/scheme/:schemeId"
-            render={this.schemeProposalsPageHtml(isActive)} />
+            render={this.schemeProposalsPageHtml(isActive, daoState)} />
         </Switch>
       </div>
     );

--- a/src/components/Scheme/SchemeInfoPage.tsx
+++ b/src/components/Scheme/SchemeInfoPage.tsx
@@ -2,14 +2,14 @@
 
 import * as React from "react";
 import { BreadcrumbsItem } from "react-breadcrumbs-dynamic";
-import { Address, ISchemeState, IGenesisProtocolParams } from "@daostack/client";
+import { Address, ISchemeState, IGenesisProtocolParams, IDAOState } from "@daostack/client";
 import { copyToClipboard, fromWei, linkToEtherScan, schemeName, roundUp } from "lib/util";
 import * as moment from "moment";
 import Tooltip from "rc-tooltip";
 import * as css from "./SchemeInfo.scss";
 
 interface IProps {
-  daoAvatarAddress: Address;
+  daoState: IDAOState;
   scheme: ISchemeState;
 }
 
@@ -18,7 +18,8 @@ export default class SchemeInfo extends React.Component<IProps, null> {
   private copyToClipboardHandler = (str: string) => (_event: any) => { copyToClipboard(str); };
 
   public render(): RenderOutput {
-    const { daoAvatarAddress, scheme } = this.props;
+    const { daoState, scheme } = this.props;
+    const daoAvatarAddress = daoState.address;
 
     const duration = (durationSeconds: number): any => {
 

--- a/src/components/Scheme/SchemeProposalsPage.tsx
+++ b/src/components/Scheme/SchemeProposalsPage.tsx
@@ -8,7 +8,7 @@ import { schemeName} from "lib/util";
 import * as React from "react";
 import { BreadcrumbsItem } from "react-breadcrumbs-dynamic";
 import * as InfiniteScroll from "react-infinite-scroll-component";
-import { Link, RouteComponentProps } from "react-router-dom";
+import { Link } from "react-router-dom";
 import { CSSTransition, TransitionGroup } from "react-transition-group";
 import { Observable, combineLatest } from "rxjs";
 import { connect } from "react-redux";
@@ -36,18 +36,19 @@ const Fade = ({ children, ...props }: any): any => (
   </CSSTransition>
 );
 
-interface IExternalProps extends RouteComponentProps<any> {
+interface IExternalProps {
   currentAccountAddress: Address;
   history: H.History;
   isActive: boolean;
   scheme: ISchemeState;
+  daoState: IDAOState;
 }
 
 interface IDispatchProps {
   showNotification: typeof showNotification;
 }
 
-type SubscriptionData = [Proposal[], Proposal[], Proposal[], IDAOState, Proposal[]];
+type SubscriptionData = [Proposal[], Proposal[], Proposal[], Proposal[]];
 type IProps = IExternalProps & IDispatchProps & ISubscriptionProps<SubscriptionData>;
 
 const mapDispatchToProps = {
@@ -63,22 +64,22 @@ class SchemeProposalsPage extends React.Component<IProps, null> {
   }
 
   private _handleNewProposal = (e: any): void => {
-    this.handleNewProposal(this.props.data[3].address, this.props.scheme.id);
+    this.handleNewProposal(this.props.daoState.address, this.props.scheme.id);
     e.preventDefault();
   };
 
   public render(): RenderOutput {
     const { data } = this.props;
 
-    const [proposalsQueued, proposalsPreBoosted, proposalsBoosted, dao] = data;
-    const { currentAccountAddress, fetchMore, isActive, scheme } = this.props;
+    const [proposalsQueued, proposalsPreBoosted, proposalsBoosted ] = data;
+    const { currentAccountAddress, daoState, fetchMore, isActive, scheme } = this.props;
     let proposalCount=0;
 
     const queuedProposalsHTML = (
       <TransitionGroup className="queued-proposals-list">
         { proposalsQueued.map((proposal: Proposal): any => (
           <Fade key={"proposal_" + proposal.id}>
-            <ProposalCard proposal={proposal} daoState={dao} currentAccountAddress={currentAccountAddress} suppressTrainingTooltips={proposalCount++ > 0} />
+            <ProposalCard proposal={proposal} daoState={daoState} currentAccountAddress={currentAccountAddress} suppressTrainingTooltips={proposalCount++ > 0}/>
           </Fade>
         ))}
       </TransitionGroup>
@@ -90,7 +91,7 @@ class SchemeProposalsPage extends React.Component<IProps, null> {
       <TransitionGroup className="boosted-proposals-list">
         { proposalsPreBoosted.map((proposal: Proposal): any => (
           <Fade key={"proposal_" + proposal.id}>
-            <ProposalCard proposal={proposal} daoState={dao} currentAccountAddress={currentAccountAddress}  suppressTrainingTooltips={proposalCount++ > 0}/>
+            <ProposalCard proposal={proposal} daoState={daoState} currentAccountAddress={currentAccountAddress} suppressTrainingTooltips={proposalCount++ > 0}/>
           </Fade>
         ))}
       </TransitionGroup>
@@ -102,7 +103,7 @@ class SchemeProposalsPage extends React.Component<IProps, null> {
       <TransitionGroup className="boosted-proposals-list">
         { proposalsBoosted.map((proposal: Proposal): any => (
           <Fade key={"proposal_" + proposal.id}>
-            <ProposalCard proposal={proposal} daoState={dao} currentAccountAddress={currentAccountAddress}  suppressTrainingTooltips={proposalCount++ > 0}/>
+            <ProposalCard proposal={proposal} daoState={daoState} currentAccountAddress={currentAccountAddress} suppressTrainingTooltips={proposalCount++ > 0}/>
           </Fade>
         ))}
       </TransitionGroup>
@@ -110,7 +111,7 @@ class SchemeProposalsPage extends React.Component<IProps, null> {
 
     return (
       <div>
-        <BreadcrumbsItem to={`/dao/${dao.address}/scheme/${scheme.id}`}>{schemeName(scheme, scheme.address)}</BreadcrumbsItem>
+        <BreadcrumbsItem to={`/dao/${daoState.address}/scheme/${scheme.id}`}>{schemeName(scheme, scheme.address)}</BreadcrumbsItem>
 
         { proposalsQueued.length === 0 && proposalsPreBoosted.length === 0 && proposalsBoosted.length === 0
           ?
@@ -121,7 +122,7 @@ class SchemeProposalsPage extends React.Component<IProps, null> {
             </div>
             <p>You can be the first one to create a {scheme.name && scheme.name.replace(/([A-Z])/g, " $1") || scheme.address} proposal today! (:</p>
             <div className={css.cta}>
-              <Link to={"/dao/" + dao.address}>
+              <Link to={"/dao/" + daoState.address}>
                 <img className={css.relax} src="/assets/images/lt.svg"/> Back to schemes
               </Link>
               <a className={classNames({
@@ -214,14 +215,12 @@ const SubscribedSchemeProposalsPage = withSubscription<IProps, SubscriptionData>
   errorComponent: null,
 
   checkForUpdate: (oldProps, newProps) => {
-    return oldProps.match.params.daoAvatarAddress !== oldProps.match.params.daoAvatarAddress
-           || oldProps.scheme.id !== newProps.scheme.id;
+    return oldProps.scheme.id !== newProps.scheme.id;
   },
 
   createObservable: async (props: IExternalProps) => {
-    const daoAvatarAddress = props.match.params.daoAvatarAddress;
     const arc = getArc();
-    const dao = arc.dao(daoAvatarAddress);
+    const dao = props.daoState.dao;
     const schemeId = props.scheme.id;
 
     // this query will fetch al data we need before rendering the page, so we avoid hitting the server
@@ -297,18 +296,13 @@ const SubscribedSchemeProposalsPage = withSubscription<IProps, SubscriptionData>
         where: { scheme: schemeId, stage_in: [IProposalStage.Boosted, IProposalStage.QuietEndingPeriod] },
         orderBy: "boostedAt",
       }, { subscribe: true}),
-
-      // DAO state
-      dao.state(),
       // big subscription query to make all other subscription queries obsolete
       arc.getObservable(bigProposalQuery, {subscribe: true}) as Observable<Proposal[]>,
     );
   },
 
   getFetchMoreObservable: (props: IExternalProps, data: SubscriptionData) => {
-    const daoAvatarAddress = props.match.params.daoAvatarAddress;
-    const arc = getArc();
-    const dao = arc.dao(daoAvatarAddress);
+    const dao = props.daoState.dao;
 
     return dao.proposals({
       // eslint-disable-next-line @typescript-eslint/camelcase
@@ -321,7 +315,7 @@ const SubscribedSchemeProposalsPage = withSubscription<IProps, SubscriptionData>
   },
 
   fetchMoreCombine: (prevState: SubscriptionData, newData: Proposal[]) => {
-    return [prevState[0].concat(newData), prevState[1], prevState[2], prevState[3], []];
+    return [prevState[0].concat(newData), prevState[1], prevState[2], []];
   },
 });
 

--- a/src/layouts/Header.tsx
+++ b/src/layouts/Header.tsx
@@ -277,7 +277,8 @@ const SubscribedHeader = withSubscription({
   createObservable: (props: IProps) => {
     if (props.daoAvatarAddress) {
       const arc = getArc();
-      return arc.dao(props.daoAvatarAddress).state();
+      // subscribe if only to get DAO reputation supply updates
+      return arc.dao(props.daoAvatarAddress).state({ subscribe: true });
     } else {
       return of(null);
     }


### PR DESCRIPTION
Resolves:  https://github.com/daostack/alchemy/issues/1171
Resolves: https://daostack.tpondemand.com/RestUI/Board.aspx#page=board/5209716961861964288&appConfig=eyJhY2lkIjoiQjgzMTMzNDczNzlCMUI5QUE0RUE1NUVEOUQyQzdFNkIifQ==&boardPopup=bug/1749/silent

* Fixes the 125% issue in the original use case as well as everywhere else where the reputation percentage is displayed.  Accomplished this by subscribing to changes in the DAOstate whereever `DAOstate.reputationTotalSupply` is used.
* cleans up some places where the dao state is being redundantly created.

**Note** there still remain some places that create their own instances of DAO and DAOstate.  These are characterized as being code that is not under `DAOContainer`, for example the app header, redemptions menu and account profile code.  So ideally we would be creating and subscribing to the DAO and DAOstate in `AppContainer` rather than `DAOContainer`.  Simply in the interest of time and a perhaps lazy call that this good-enough, I didn't go that far in refactoring.  **However** note that these are now creating their own subscriptions, thus adding modestly to the number of subscriptions created by the app.

**Question** should we be setting ``fetchAllData` to true on the top-level DAOstate in DaoContainer? 