### PR TITLE
fix several issues with redemption tooltip and action button

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ### template
   - Features Added
+    - prevent redemptions when nothing will happen due to insuffucient DAO resources.  Warn on partial redemptions.
   - Bugs Fixed
 
 ## Next release

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,10 @@
 ### template
   - Features Added
-    - prevent redemptions when nothing will happen due to insuffucient DAO resources.  Warn on partial redemptions.
   - Bugs Fixed
 
 ## Next release
   - Features Added
+    - prevent redemptions when nothing will happen due to insuffucient DAO resources.  Warn on partial redemptions.
   - Bugs Fixed
 
 ### 2019-11-12

--- a/src/components/Proposal/ActionButton.scss
+++ b/src/components/Proposal/ActionButton.scss
@@ -58,6 +58,12 @@
 }
 
 .redeemButton {
+
+  &:disabled {
+    background-color: rgba(200,200,200,.5);
+    color: rgba(75,75,75,1);
+  }
+
   img {
     margin-left: -1px;
     margin-right: 1px;

--- a/src/components/Proposal/ActionButton.tsx
+++ b/src/components/Proposal/ActionButton.tsx
@@ -122,11 +122,13 @@ class ActionButton extends React.Component<IProps, IState> {
     const availableGpRewards = getGpRewards(rewards, daoBalances);
     // only true if there are rewards and the DAO can't pay them. false if there are no rewards or they can be paid.
     const daoLacksRequiredGpRewards = Object.keys(availableGpRewards).length < currentAccountNumUnredeemedGpRewards;
+    const daoLacksAllRequiredGpRewards = (Object.keys(availableGpRewards).length === 0) && (currentAccountNumUnredeemedGpRewards > 0);
     /**
      * note beneficiary may not be the current account
      */
     let beneficiaryNumUnredeemedCrRewards = 0;
     let daoLacksRequiredCrRewards = false;
+    let daoLacksAllRequiredCrRewards = false;
     let contributionRewards;
     if (proposalState.contributionReward) {
       /**
@@ -140,6 +142,7 @@ class ActionButton extends React.Component<IProps, IState> {
       const availableCrRewards = getCRRewards(proposalState.contributionReward, daoBalances);
       // only true if there are rewards and the DAO can't pay them. false if there are no rewards or they can be paid.
       daoLacksRequiredCrRewards = Object.keys(availableCrRewards).length < beneficiaryNumUnredeemedCrRewards;
+      daoLacksAllRequiredCrRewards = (Object.keys(availableCrRewards).length === 0) && (beneficiaryNumUnredeemedCrRewards > 0);
     }
     // account or beneficiary has a reward
     const hasRewards = (beneficiaryNumUnredeemedCrRewards > 0) || (currentAccountNumUnredeemedGpRewards > 0);
@@ -149,9 +152,12 @@ class ActionButton extends React.Component<IProps, IState> {
                           ((currentAccountNumUnredeemedGpRewards === 0) || !daoLacksRequiredGpRewards));
 
     // true if there exist one or more rewards and not any one of them can be paid
-    const canRewardNone = hasRewards &&
-                            !(((beneficiaryNumUnredeemedCrRewards > 0) && !daoLacksRequiredCrRewards) ||
-                             ((currentAccountNumUnredeemedGpRewards > 0) && !daoLacksRequiredGpRewards));
+    let canRewardNone=false;
+    if (daoLacksAllRequiredCrRewards) {
+      canRewardNone = daoLacksAllRequiredGpRewards || (currentAccountNumUnredeemedGpRewards === 0);
+    } else if (daoLacksAllRequiredGpRewards) {
+      canRewardNone = (beneficiaryNumUnredeemedCrRewards === 0);
+    }
 
     const canRewardSomeNotAll = hasRewards && !canRewardAll && !canRewardNone;
 

--- a/src/components/Proposal/RedemptionsTip.tsx
+++ b/src/components/Proposal/RedemptionsTip.tsx
@@ -21,8 +21,8 @@ export default (props: IProps) => {
 
   const messageDiv = (canRewardNone || canRewardOnlySome) ? <div className={css.message}>
     <img className={css.icon} src="/assets/images/Icon/Alert-yellow-b.svg" />
-    {canRewardNone ? <div className={css.text}>At this time, none of these rewards can be redeemed -- the DAO does not have the necessary assets.</div> : ""}
-    {canRewardOnlySome ? <div className={css.text}>At this time, only some of these rewards can be redeemed -- the DAO does not have the necessary assets.</div> : ""}
+    {canRewardNone ? <div className={css.text}>At this time, none of these rewards can be redeemed -- {dao.name} does not hold all the necessary assets.</div> : ""}
+    {canRewardOnlySome ? <div className={css.text}>At this time, only some of these rewards can be redeemed -- {dao.name} does not hold all the necessary assets.</div> : ""}
   </div> : <span></span>;
   
   const rewardComponents = [];
@@ -58,7 +58,7 @@ export default (props: IProps) => {
     c = <div key={id + "_staker_bounty"}>
       <strong>For staking on the proposal you are due to receive:</strong>
       <ul>
-        <li>{fromWei(gpRewards.daoBountyForStaker)} bounty from the DAO
+        <li>{fromWei(gpRewards.daoBountyForStaker)} GEN as bounty from {dao.name}
         </li>
       </ul>
     </div >;

--- a/src/components/Redemptions/RedemptionsPage.scss
+++ b/src/components/Redemptions/RedemptionsPage.scss
@@ -3,6 +3,10 @@
   max-width: $max-width;
   margin: 0 auto;
   padding: 0 30px;
+
+  h3.pleaseLogin {
+    text-align: center;
+  }
 }
 
 .loading {

--- a/src/components/Redemptions/RedemptionsPage.tsx
+++ b/src/components/Redemptions/RedemptionsPage.tsx
@@ -46,7 +46,7 @@ class RedemptionsPage extends React.Component<IProps, null> {
 
     if (data === null) {
       return <div className={css.wrapper}>
-        Please log in to see your rewards.
+        <h3 className={css.pleaseLogin}>Please log in to see your rewards.</h3>
       </div>;
     }
 

--- a/src/components/Shared/PreTransactionModal.scss
+++ b/src/components/Shared/PreTransactionModal.scss
@@ -776,7 +776,9 @@ input[type=number] {
   padding-top: 8px;
 
   .message {
-    padding-bottom: 8px;
+    padding-bottom: 6px;
+    border-bottom: $gray-border;
+    margin-bottom: 6px;
     .icon {
       display: inline-block;
       margin-right:6px;

--- a/test/integration/rewards.ts
+++ b/test/integration/rewards.ts
@@ -1,5 +1,5 @@
 import * as chai from "chai";
-import { getContractAddresses } from "./utils";
+import { getContractAddresses, hideCookieAcceptWindow } from "./utils";
 
 chai.should();
 
@@ -63,6 +63,13 @@ describe("Redemptions page", () => {
   });
 
   it("should redeem a reward", async () => {
+    await hideCookieAcceptWindow();
+    
+    await browser.url("http://127.0.0.1:3000/redemptions");
+    const connectButton = await $("*[data-test-id=\"connectButton\"]");
+    await connectButton.waitForDisplayed();
+    await connectButton.click();
+
     const proposalId = testAddresses.test.executedProposalId;
     const proposalCard = await $(`[data-test-id="proposal-${proposalId}"]`);
     await proposalCard.waitForExist();

--- a/test/integration/utils.ts
+++ b/test/integration/utils.ts
@@ -63,7 +63,5 @@ export async function hideCookieAcceptWindow(): Promise<void> {
 }
 
 export async function hideTrainingTooltips() {
-  if (localStorage) {
-    localStorage.setItem("trainingTooltipsEnabled", "false");
-  }
+  localStorage.setItem("trainingTooltipsEnabled", "false");
 }

--- a/test/integration/utils.ts
+++ b/test/integration/utils.ts
@@ -63,5 +63,7 @@ export async function hideCookieAcceptWindow(): Promise<void> {
 }
 
 export async function hideTrainingTooltips() {
-  localStorage.setItem("trainingTooltipsEnabled", "false");
+  if (localStorage) {
+    localStorage.setItem("trainingTooltipsEnabled", "false");
+  }
 }


### PR DESCRIPTION
Resolves: 
 
 https://daostack.tpondemand.com/RestUI/Board.aspx#page=board/5209716961861964288&appConfig=eyJhY2lkIjoiQjgzMTMzNDczNzlCMUI5QUE0RUE1NUVEOUQyQzdFNkIifQ==&boardPopup=bug/1817/silent

(Should not say insufficient resources for just redeeming rep)

and parts of:
 
 
 
 https://daostack.tpondemand.com/RestUI/Board.aspx#page=board/5209716961861964288&appConfig=eyJhY2lkIjoiQjgzMTMzNDczNzlCMUI5QUE0RUE1NUVEOUQyQzdFNkIifQ==&boardPopup=bug/1804/silent

Of the latter:

* disables Redeem button if nothing can be redeemed due to lack of funds.  Makes it look disabled when disabled.
* corrects logic governing when the Redeem button should be visible
* corrects logic for when Redeem button text should say "For Beneficiary"

Also:

* a few helpful changes to the redemptions tooltip text and the style of the tooltip
