### PR TITLE
error page on unregistered DAOs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ## Next release
   - Features Added
   - Bugs Fixed
+    - go to error page on non-existent or unregistered DAOs
 
 ### 2019-11-12
   - Features added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@
 ## Next release
   - Features Added
   - Bugs Fixed
-    - go to error page on non-existent or unregistered DAOs
+    - go to error page on non-existent DAOs
 
 ### 2019-11-12
   - Features added

--- a/src/components/Dao/DaoContainer.tsx
+++ b/src/components/Dao/DaoContainer.tsx
@@ -15,8 +15,7 @@ import { ModalRoute } from "react-router-modal";
 import { IRootState } from "reducers";
 import { showNotification } from "reducers/notifications";
 import { IProfileState } from "reducers/profilesReducer";
-import { Subscription, of } from "rxjs";
-import { first } from "rxjs/operators";
+import { Subscription } from "rxjs";
 import DaoDiscussionPage from "./DaoDiscussionPage";
 import DaoSchemesPage from "./DaoSchemesPage";
 import DaoHistoryPage from "./DaoHistoryPage";
@@ -120,16 +119,10 @@ const SubscribedDaoContainer = withSubscription({
   loadingComponent: <div className={css.loading}><Loading/></div>,
   errorComponent: (props) => <div>{props.error.message}</div>,
   checkForUpdate: ["daoAvatarAddress"],
-  createObservable: async (props: IExternalProps) => {
+  createObservable: (props: IExternalProps) => {
     const arc = getArc(); // TODO: maybe we pass in the arc context from withSubscription instead of creating one every time?
     const daoAddress = props.match.params.daoAvatarAddress;
-    const daoState = await arc.dao(daoAddress).state().pipe(first()).toPromise();
-    if ((process.env.NODE_ENV === "production") && (daoState.register !== "registered")) {
-      // this will go to the error page
-      throw new Error(`The DAO ${daoState.name} has not been registered`);
-    } else {
-      return of(daoState);
-    }
+    return arc.dao(daoAddress).state();
   },
 });
 

--- a/src/components/Shared/withSubscription.tsx
+++ b/src/components/Shared/withSubscription.tsx
@@ -116,10 +116,7 @@ const withSubscription = <Props extends ISubscriptionProps<ObservableType>, Obse
           // eslint-disable-next-line no-console
           console.error(getDisplayName(wrappedComponent), "Error in subscription", error);
 
-          this.setState({
-            isLoading: false,
-            error,
-          });
+          this.setState(() => { throw error; });
         },
         () => { this.setState({
           complete: true,

--- a/src/components/Shared/withSubscription.tsx
+++ b/src/components/Shared/withSubscription.tsx
@@ -115,7 +115,7 @@ const withSubscription = <Props extends ISubscriptionProps<ObservableType>, Obse
         (error: Error) => {
           // eslint-disable-next-line no-console
           console.error(getDisplayName(wrappedComponent), "Error in subscription", error);
-
+          // this will go to the error page
           this.setState(() => { throw error; });
         },
         () => { this.setState({


### PR DESCRIPTION
Resolves:

https://daostack.tpondemand.com/RestUI/Board.aspx#page=board/5209716961861964288&appConfig=eyJhY2lkIjoiQjgzMTMzNDczNzlCMUI5QUE0RUE1NUVEOUQyQzdFNkIifQ==&boardPopup=bug/1802/silent

Goes to error page on non-existent DAOs

**Note** that the code that handles non-existent DAOs has the potential to trap other types of exceptions and redirect to the error page.