### PR TITLE
add subscriptions for votes, stakes and rewards

### DIFF
--- a/src/components/Proposal/ProposalData.tsx
+++ b/src/components/Proposal/ProposalData.tsx
@@ -123,7 +123,7 @@ export default withSubscription({
 
     if (currentAccountAddress) {
       return combineLatest(
-        proposal.state({ subscribe: true }), // state of the current proposal
+        proposal.state({ subscribe: props.subscribeToProposalDetails }), // state of the current proposal
         proposal.votes({where: { voter: currentAccountAddress }}, { subscribe: props.subscribeToProposalDetails }),
         proposal.stakes({where: { staker: currentAccountAddress }}, { subscribe: props.subscribeToProposalDetails }),
         proposal.rewards({ where: {beneficiary: currentAccountAddress}}, { subscribe: props.subscribeToProposalDetails })

--- a/src/components/Proposal/ProposalData.tsx
+++ b/src/components/Proposal/ProposalData.tsx
@@ -20,6 +20,10 @@ interface IExternalProps {
   dao: IDAOState;
   proposalId: string;
   children(props: IInjectedProposalProps): JSX.Element;
+  /**
+   * true to subscribe to changes in votes, stakes and rewards
+   */
+  subscribeToProposalDetails?: boolean;
 }
 
 interface IStateProps {
@@ -120,9 +124,9 @@ export default withSubscription({
     if (currentAccountAddress) {
       return combineLatest(
         proposal.state({ subscribe: true }), // state of the current proposal
-        proposal.votes({where: { voter: currentAccountAddress }}, { subscribe: true }),
-        proposal.stakes({where: { staker: currentAccountAddress }}, { subscribe: true }),
-        proposal.rewards({ where: {beneficiary: currentAccountAddress}}, { subscribe: true })
+        proposal.votes({where: { voter: currentAccountAddress }}, { subscribe: props.subscribeToProposalDetails }),
+        proposal.stakes({where: { staker: currentAccountAddress }}, { subscribe: props.subscribeToProposalDetails }),
+        proposal.rewards({ where: {beneficiary: currentAccountAddress}}, { subscribe: props.subscribeToProposalDetails })
           .pipe(map((rewards: Reward[]): Reward => rewards.length === 1 && rewards[0] || null))
           .pipe(mergeMap(((reward: Reward): Observable<IRewardState> => reward ? reward.state() : of(null)))),
 

--- a/src/components/Proposal/ProposalData.tsx
+++ b/src/components/Proposal/ProposalData.tsx
@@ -119,10 +119,10 @@ export default withSubscription({
 
     if (currentAccountAddress) {
       return combineLatest(
-        proposal.state(), // state of the current proposal
-        proposal.votes({where: { voter: currentAccountAddress }}),
-        proposal.stakes({where: { staker: currentAccountAddress }}),
-        proposal.rewards({ where: {beneficiary: currentAccountAddress}})
+        proposal.state({ subscribe: true }), // state of the current proposal
+        proposal.votes({where: { voter: currentAccountAddress }}, { subscribe: true }),
+        proposal.stakes({where: { staker: currentAccountAddress }}, { subscribe: true }),
+        proposal.rewards({ where: {beneficiary: currentAccountAddress}}, { subscribe: true })
           .pipe(map((rewards: Reward[]): Reward => rewards.length === 1 && rewards[0] || null))
           .pipe(mergeMap(((reward: Reward): Observable<IRewardState> => reward ? reward.state() : of(null)))),
 

--- a/src/components/Proposal/ProposalDetailsPage.tsx
+++ b/src/components/Proposal/ProposalDetailsPage.tsx
@@ -72,7 +72,7 @@ export default class ProposalDetailsPage extends React.Component<IProps, IState>
   public render(): RenderOutput {
     const { currentAccountAddress, daoState, proposalId } = this.props;
 
-    return <ProposalData currentAccountAddress={currentAccountAddress} dao={daoState} proposalId={proposalId}>
+    return <ProposalData currentAccountAddress={currentAccountAddress} dao={daoState} proposalId={proposalId} subscribeToProposalDetails>
       { props => {
         const {
           beneficiaryProfile,

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -32,6 +32,6 @@ export const settings = {
       "api-path": process.env.ARC_IPFSPROVIDER_API_PATH || "/ipfs-daostack/api/v0/",
     },
     // txSenderServiceUrl: "https://tx-sender-service-mainnet.herokuapp.com/send-tx",
-    txSenderServiceUrl: undefined,
+    txSenderServiceUrl: "",
   },
 };


### PR DESCRIPTION
Resolves: https://daostack.tpondemand.com/RestUI/Board.aspx#page=board/5209716961861964288&appConfig=eyJhY2lkIjoiQjgzMTMzNDczNzlCMUI5QUE0RUE1NUVEOUQyQzdFNkIifQ==&boardPopup=bug/1756/silent

This fixes not just voting feedback, but also staking and anything related to redemptions.

I feel weird about adding subscriptions, but don't know another way to address this unless we can do a fetchAllData on the proposal itself and subscribe directly to it.  But that makes me feel weird too, so will defer to @jellegerbrandy on the best way to do this.