### PR TITLE
better position notifs on all pages

### DIFF
--- a/src/components/Notification/Notification.scss
+++ b/src/components/Notification/Notification.scss
@@ -137,14 +137,6 @@
   }
 }
 
-.right {
-  float: right;
-}
-
-.left {
-  float: left;
-}
-
 .statusIcon {
   float: left;
 }

--- a/src/layouts/App.scss
+++ b/src/layouts/App.scss
@@ -517,7 +517,7 @@ body {
   position: fixed;
   bottom: 50px;
   background-color: rgba(255,255,255,1);
-  left: 260px;
+  left: 20px;
   width: 290px;
   height: auto;
   text-align: left;


### PR DESCRIPTION
Resolves: https://daostack.tpondemand.com/RestUI/Board.aspx#page=board/5209716961861964288&appConfig=eyJhY2lkIjoiQjgzMTMzNDczNzlCMUI5QUE0RUE1NUVEOUQyQzdFNkIifQ==&boardPopup=bug/1564/silent

Now provides better visibility on all pages, including being better on DAO-related pages.

Looks like this:

On home (DAOs) page:

![image](https://user-images.githubusercontent.com/1821666/70083122-d0991000-15d9-11ea-8f85-d5641f8f62ba.png)

On DAO page (with DaoSideBar):

![image](https://user-images.githubusercontent.com/1821666/70083138-dbec3b80-15d9-11ea-99e9-c1347becaf63.png)

