### PR TITLE
Update # rep to redeem from tokens when switching account

### DIFF
--- a/src/actions/arcActions.ts
+++ b/src/actions/arcActions.ts
@@ -144,7 +144,7 @@ export function redeemProposal(daoAvatarAddress: string, proposalId: string, acc
   };
 }
 
-export function redeemReputationFromToken(scheme: Scheme, addressToRedeem: string, privateKey: string|undefined, redeemerAddress: Address|undefined) {
+export function redeemReputationFromToken(scheme: Scheme, addressToRedeem: string, privateKey: string|undefined, redeemerAddress: Address|undefined, redemptionSucceededCallback: () => void) {
   return async (dispatch: Redux.Dispatch<any, any>) => {
     const arc = getArc();
 
@@ -181,6 +181,7 @@ export function redeemReputationFromToken(scheme: Scheme, addressToRedeem: strin
       try {
         await arc.web3.eth.sendSignedTransaction(signedTransaction.rawTransaction);
         dispatch(showNotification(NotificationStatus.Success, "Transaction was succesful!"));
+        redemptionSucceededCallback();
       } catch(err) {
         dispatch(showNotification(NotificationStatus.Failure, `Transaction failed: ${err.message}`));
       }
@@ -191,7 +192,7 @@ export function redeemReputationFromToken(scheme: Scheme, addressToRedeem: strin
       // send the transaction and get notifications
       if (reputationFromTokenScheme) {
         const agreementHash = await reputationFromTokenScheme.getAgreementHash();
-        reputationFromTokenScheme.redeem(addressToRedeem, agreementHash).subscribe(...observer);
+        reputationFromTokenScheme.redeem(addressToRedeem, agreementHash).subscribe(observer[0], observer[1], redemptionSucceededCallback);
       }
     }
   };

--- a/src/components/Scheme/ReputationFromToken.tsx
+++ b/src/components/Scheme/ReputationFromToken.tsx
@@ -91,8 +91,7 @@ class ReputationFromToken extends React.Component<IProps, IState> {
     };
   }
 
-  private async _loadReputationBalance() {
-    const redeemerAddress = this.state.redeemerAddress;
+  private async _loadReputationBalance(redeemerAddress: string) {
     if (redeemerAddress) {
       const schemeState = this.props.schemeState;
       const schemeAddress = schemeState.address;
@@ -111,25 +110,24 @@ class ReputationFromToken extends React.Component<IProps, IState> {
       this.setState({
         redemptionAmount,
         alreadyRedeemed,
+        redeemerAddress,
       });
     } else {
       this.setState({
         redemptionAmount: new BN(0),
         alreadyRedeemed: false,
+        redeemerAddress: null,
       });
     }
   }
 
   public async componentDidMount() {
-    await this._loadReputationBalance();
+    await this._loadReputationBalance(this.state.redeemerAddress);
   }
 
   public async componentDidUpdate(prevProps: IProps) {
     if (!this.state.privateKey && this.props.currentAccountAddress !== prevProps.currentAccountAddress) {
-      this.setState({
-        redeemerAddress: this.props.currentAccountAddress,
-      });
-      await this._loadReputationBalance();
+      await this._loadReputationBalance(this.props.currentAccountAddress);
     }
   }
 
@@ -148,6 +146,7 @@ class ReputationFromToken extends React.Component<IProps, IState> {
     const alreadyRedeemed = await schemeContract.methods.redeems(this.state.redeemerAddress).call();
     if (alreadyRedeemed) {
       this.props.showNotification(NotificationStatus.Failure, `Reputation for the account ${this.state.redeemerAddress} was already redeemed`);
+      this.redemptionSucceeded();
     } else if (values.useTxSenderService === true) {
       // construct the message to sign
       // const signatureType = 1
@@ -241,6 +240,7 @@ class ReputationFromToken extends React.Component<IProps, IState> {
             this.props.showNotification(NotificationStatus.Failure, `An error occurred on the transaction service: ${response.data.status}: ${response.data.message}`);
           } else {
             this.props.showNotification(NotificationStatus.Success, `You've successfully redeemed rep to ${values.accountAddress}`);
+            this.redemptionSucceeded();
           }
         } catch(err) {
           this.props.showNotification(NotificationStatus.Failure, `${err.message}}`);
@@ -255,9 +255,13 @@ class ReputationFromToken extends React.Component<IProps, IState> {
       // ,{from:_fromAccount}));
     } else {
       const scheme = arc.scheme(schemeState.id);
-      this.props.redeemReputationFromToken(scheme, values.accountAddress, this.state.privateKey, this.state.redeemerAddress);
+      await this.props.redeemReputationFromToken(scheme, values.accountAddress, this.state.privateKey, this.state.redeemerAddress, this.redemptionSucceeded);
     }
     setSubmitting(false);
+  }
+
+  public redemptionSucceeded = () => {
+    this.setState( { redemptionAmount: new BN(0) });
   }
 
   private onSubmitClick = (setFieldValue: any) => ()=>{ setFieldValue("useTxSenderService",false); }

--- a/src/components/Scheme/ReputationFromToken.tsx
+++ b/src/components/Scheme/ReputationFromToken.tsx
@@ -84,7 +84,7 @@ class ReputationFromToken extends React.Component<IProps, IState> {
 
 
     this.state = {
-      redemptionAmount: null,
+      redemptionAmount: new BN(0),
       alreadyRedeemed: false,
       privateKey: pk,
       redeemerAddress,
@@ -337,7 +337,7 @@ class ReputationFromToken extends React.Component<IProps, IState> {
                 </div>
                 <div className={schemeCss.redemptionButton}>
                   <button type="submit"
-                    disabled={false}
+                    disabled={this.state.alreadyRedeemed || this.state.redemptionAmount.isZero()}
                     onClick={this.onSubmitClick(setFieldValue)}
                   >
                     <img src="/assets/images/Icon/redeem.svg"/> Redeem
@@ -347,7 +347,7 @@ class ReputationFromToken extends React.Component<IProps, IState> {
                   <div className={schemeCss.redemptionButton}>
                     <div>Or try our new experimental feature:</div>
                     <button type="submit"
-                      disabled={false}
+                      disabled={this.state.alreadyRedeemed || this.state.redemptionAmount.isZero()}
                       onClick={this.onSubmitClick(setFieldValue)}
                     >
                       <img src="/assets/images/Icon/redeem.svg"/> Redeem w/o paying gas


### PR DESCRIPTION
Also attempt to set to 0 after redeem succeeds, but hard to do this with current client library, see https://github.com/daostack/client/issues/412

Also disable redeem buttons when 0 rep to redeem

Fixes https://github.com/daostack/alchemy/issues/1348 & https://github.com/daostack/alchemy/issues/1319