### PR TITLE
Interestingly, setting devtool to source-maps on prod makes the bundl…

### DIFF
--- a/webpack.prod.config.js
+++ b/webpack.prod.config.js
@@ -12,7 +12,7 @@ const baseConfig = require('./webpack.base.config.js');
 const config = merge(baseConfig, {
   mode: 'production',
 
-  //devtool: 'nosources-source-map',
+  devtool: 'source-map',
 
   entry: {
     // the entry point of our app


### PR DESCRIPTION
…e smaller.

The gzipped app bundle goes from 155 KB to 114 KB!
I'm not sure what the default is that it was using before, must have been some inline source maps, so this is better.  And we get to keep source maps on production for debugging

Related to https://github.com/daostack/alchemy/issues/1329