### PR TITLE
Fixing the hex byte pattern regex in Generic Scheme Proposal Form

### DIFF
--- a/src/components/Proposal/Create/SchemeForms/CreateUnknownGenericSchemeProposal.tsx
+++ b/src/components/Proposal/Create/SchemeForms/CreateUnknownGenericSchemeProposal.tsx
@@ -137,7 +137,7 @@ class CreateGenericScheme extends React.Component<IProps, IStateProps> {
               errors.url = "Invalid URL";
             }
 
-            const bytesPattern = new RegExp("0x[0-9a-e]+", "i");
+            const bytesPattern = new RegExp("0x[0-9a-f]+", "i");
             if (values.callData && !bytesPattern.test(values.callData)) {
               errors.callData = "Invalid encoded function call data";
             }


### PR DESCRIPTION
to allow character `f`
see #1454 