### PR TITLE
Fix Windows Install

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2167,24 +2167,24 @@
       }
     },
     "@devexpress/dx-core": {
-      "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/@devexpress/dx-core/-/dx-core-2.4.0.tgz",
-      "integrity": "sha512-6N+S3qhpu3mAGsM4ShCVJO+xN6Da53tak5S6ZN+aMhlHMvQMAol56RmOF5HdYc3muzIRC190o9pFHjNGV4iIQg=="
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/@devexpress/dx-core/-/dx-core-2.5.0.tgz",
+      "integrity": "sha512-hU3/VdjBwhY/dIMnn8HmSGYMs6zEArZKVG60JA6+sR28V7GiOXrTMIMSN4vE7bYyav2cqL0aSAKE00zd+/hARg=="
     },
     "@devexpress/dx-react-chart": {
-      "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/@devexpress/dx-react-chart/-/dx-react-chart-2.4.0.tgz",
-      "integrity": "sha512-u7I9nFH3B9RUTAYpegiqf81EyY1iOBcJvNxHWh2EWuyjgPs8sLLOq0HMGK8I5pT2pXdJ4nd6zjyyB3HQQKMcCA==",
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/@devexpress/dx-react-chart/-/dx-react-chart-2.5.0.tgz",
+      "integrity": "sha512-0X88q5jEMhKSKrcou7AOXN1NKekqtC0frRGWL5QqyV26/1jDIVKg1AZ4nORwTb0yzaS2x3cwqWVDX/GaWVCVMQ==",
       "requires": {
-        "@devexpress/dx-chart-core": "2.4.0",
+        "@devexpress/dx-chart-core": "2.5.0",
         "d3-scale": "^3.2.0",
         "d3-shape": "^1.3.7"
       },
       "dependencies": {
         "@devexpress/dx-chart-core": {
-          "version": "2.4.0",
-          "resolved": "https://registry.npmjs.org/@devexpress/dx-chart-core/-/dx-chart-core-2.4.0.tgz",
-          "integrity": "sha512-B3orNZeWhdS+xaY9BflpOiZhsLGZ+1d8XFCmZY2QQibXdELUcvOOPzLqvCkhNh/aqfezlNyPZENsCsP84jrYcw==",
+          "version": "2.5.0",
+          "resolved": "https://registry.npmjs.org/@devexpress/dx-chart-core/-/dx-chart-core-2.5.0.tgz",
+          "integrity": "sha512-/IZ+MOcKwupXSIIBAeBp2a9A7IWo5lSakkBbO+n4q8FPzAr1z8KSdjrIh0YTTLdp46pETY+AqrfiBFVtDpz8sA==",
           "requires": {
             "d3-array": "^2.4.0",
             "d3-scale": "^3.2.0",
@@ -2194,348 +2194,47 @@
       }
     },
     "@devexpress/dx-react-chart-material-ui": {
-      "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/@devexpress/dx-react-chart-material-ui/-/dx-react-chart-material-ui-2.4.0.tgz",
-      "integrity": "sha512-RbJCssDf2OII/GDtlycm/KL4FMKZP41zXH3zNotVCAckVjMwB8DYD+QFJelNdYwYz8/oT2jG0Jh+aAttTwHTWA==",
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/@devexpress/dx-react-chart-material-ui/-/dx-react-chart-material-ui-2.5.0.tgz",
+      "integrity": "sha512-4TonynQjUZApH+EDYErffJZSdixYrTR2AjCAkg5dUZlIh1Ls0cNMIgiJnxC6DJF2scCHoEAYoaGCvbAiuxnqsg==",
       "requires": {
         "clsx": "^1.0.4",
         "prop-types": "^15.7.2"
       }
     },
     "@devexpress/dx-react-core": {
-      "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/@devexpress/dx-react-core/-/dx-react-core-2.4.0.tgz",
-      "integrity": "sha512-9KR329NOjl2K8O2+0vQX0r/Y/MIXVru1jIfh39W/h8T7cj5at4WIeSAONwcFHr475z0f/h5m+pLMwKFzLf+Yzw==",
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/@devexpress/dx-react-core/-/dx-react-core-2.5.0.tgz",
+      "integrity": "sha512-qHEr0/Cm8wE5zmFGtKGtolSVvTyr6fw/g7oFDv9m/erVMtvpu5TyHc1/w24jhycV6cj/ZK7RsXHFGgBR8WQQBQ==",
       "requires": {
-        "@devexpress/dx-core": "2.4.0",
+        "@devexpress/dx-core": "2.5.0",
         "prop-types": "^15.7.2"
       }
     },
     "@dorgtech/daocreator-lib": {
-      "version": "0.2.1-rc.18",
-      "resolved": "https://registry.npmjs.org/@dorgtech/daocreator-lib/-/daocreator-lib-0.2.1-rc.18.tgz",
-      "integrity": "sha512-UjZW4hrUBNKtbTz/U7zEerPP2ju6x1lHCRCR38Ea2Dkhu2sW8tSJ2Q/qHG6Rme/faUHD4BPkWHzUMAzcSJsQjw==",
+      "version": "1.0.0-beta.1",
+      "resolved": "https://registry.npmjs.org/@dorgtech/daocreator-lib/-/daocreator-lib-1.0.0-beta.1.tgz",
+      "integrity": "sha512-eJnqlgQfRbBf5CLHfZGNiBjqqU+v5yL8bFVT5hoZ0s+w953MwE8CtQxhXwWelHi+KuKaIn+iBeCJ8Nx/HuTG7w==",
       "requires": {
         "bn.js": "^5.0.0",
         "csv": "^5.1.2",
         "csv-stringify": "^5.3.3",
         "formstate": "^1.3.0",
         "jsonschema": "^1.2.5",
-        "web3": "1.2.0"
+        "web3": "1.2.4"
       },
       "dependencies": {
         "bn.js": {
           "version": "5.1.1",
           "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-5.1.1.tgz",
           "integrity": "sha512-IUTD/REb78Z2eodka1QZyyEk66pciRcP6Sroka0aI3tG/iwIdYLrBD62RsubR7vqdt3WyX8p4jxeatzmRSphtA=="
-        },
-        "eth-lib": {
-          "version": "0.2.7",
-          "resolved": "https://registry.npmjs.org/eth-lib/-/eth-lib-0.2.7.tgz",
-          "integrity": "sha1-L5Pxex4jrsN1nNSj/iDBKGo/wco=",
-          "requires": {
-            "bn.js": "^4.11.6",
-            "elliptic": "^6.4.0",
-            "xhr-request-promise": "^0.1.2"
-          },
-          "dependencies": {
-            "bn.js": {
-              "version": "4.11.8",
-              "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.11.8.tgz",
-              "integrity": "sha512-ItfYfPLkWHUjckQCk8xC+LwxgK8NYcXywGigJgSwOP8Y2iyWT4f2vsZnoOXTTbo+o5yXmIUJ4gn5538SO5S3gA=="
-            }
-          }
-        },
-        "eventemitter3": {
-          "version": "3.1.2",
-          "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-3.1.2.tgz",
-          "integrity": "sha512-tvtQIeLVHjDkJYnzf2dgVMxfuSGJeM/7UCG17TT4EumTfNtF+0nebF/4zWOIkCreAbtNqhGEboB6BWrwqNaw4Q=="
-        },
-        "uuid": {
-          "version": "3.3.2",
-          "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.3.2.tgz",
-          "integrity": "sha512-yXJmeNaw3DnnKAOKJE51sL/ZaYfWJRl1pK9dr19YFCu0ObS231AB1/LbqTKRAQ5kw8A90rA6fr4riOUpTZvQZA=="
-        },
-        "web3": {
-          "version": "1.2.0",
-          "resolved": "https://registry.npmjs.org/web3/-/web3-1.2.0.tgz",
-          "integrity": "sha512-iFrVAexsopX97x0ofBU/7HrCxzovf624qBkjBUeHZDf/G3Sb4tMQtjkCRc5lgVvzureq5SCqDiFDcqnw7eJ0bA==",
-          "requires": {
-            "web3-bzz": "1.2.0",
-            "web3-core": "1.2.0",
-            "web3-eth": "1.2.0",
-            "web3-eth-personal": "1.2.0",
-            "web3-net": "1.2.0",
-            "web3-shh": "1.2.0",
-            "web3-utils": "1.2.0"
-          }
-        },
-        "web3-bzz": {
-          "version": "1.2.0",
-          "resolved": "https://registry.npmjs.org/web3-bzz/-/web3-bzz-1.2.0.tgz",
-          "integrity": "sha512-QEIdvguSEpqBK9b815nzx4yvpfKv/SAvaFeCMjQ0vjIVqFhAwBHDxd+f+X3nWGVRGVeOTP7864tau26CPBtQ8Q==",
-          "requires": {
-            "got": "9.6.0",
-            "swarm-js": "0.1.39",
-            "underscore": "1.9.1"
-          }
-        },
-        "web3-core": {
-          "version": "1.2.0",
-          "resolved": "https://registry.npmjs.org/web3-core/-/web3-core-1.2.0.tgz",
-          "integrity": "sha512-Vy+fargzx94COdihE79zIM5lb/XAl/LJlgGdmz2a6QhgGZrSL8K6DKKNS+OuORAcLJN2PWNMc4IdfknkOw1PhQ==",
-          "requires": {
-            "web3-core-helpers": "1.2.0",
-            "web3-core-method": "1.2.0",
-            "web3-core-requestmanager": "1.2.0",
-            "web3-utils": "1.2.0"
-          }
-        },
-        "web3-core-helpers": {
-          "version": "1.2.0",
-          "resolved": "https://registry.npmjs.org/web3-core-helpers/-/web3-core-helpers-1.2.0.tgz",
-          "integrity": "sha512-KLCCP2FS1cMz23Y9l3ZaEDzaUky+GpsNavl4Hn1xX8lNaKcfgGEF+DgtAY/TfPQYAxLjLrSbIFUDzo9H/W1WAQ==",
-          "requires": {
-            "underscore": "1.9.1",
-            "web3-eth-iban": "1.2.0",
-            "web3-utils": "1.2.0"
-          }
-        },
-        "web3-core-method": {
-          "version": "1.2.0",
-          "resolved": "https://registry.npmjs.org/web3-core-method/-/web3-core-method-1.2.0.tgz",
-          "integrity": "sha512-Iff5rCL+sgHe6zZVZijp818aRixKQf3ZAyQsT6ewER1r9yqXsH89DJtX33Xw8xiaYSwUFcpNs2j+Kluhv/eVAw==",
-          "requires": {
-            "underscore": "1.9.1",
-            "web3-core-helpers": "1.2.0",
-            "web3-core-promievent": "1.2.0",
-            "web3-core-subscriptions": "1.2.0",
-            "web3-utils": "1.2.0"
-          }
-        },
-        "web3-core-promievent": {
-          "version": "1.2.0",
-          "resolved": "https://registry.npmjs.org/web3-core-promievent/-/web3-core-promievent-1.2.0.tgz",
-          "integrity": "sha512-9THNYsZka91AX4LZGZvka5hio9+QlOY22hNgCiagmCmYytyKk3cXftL6CWefnNF7XgW8sy/ew5lzWLVsQW61Lw==",
-          "requires": {
-            "any-promise": "1.3.0",
-            "eventemitter3": "3.1.2"
-          }
-        },
-        "web3-core-requestmanager": {
-          "version": "1.2.0",
-          "resolved": "https://registry.npmjs.org/web3-core-requestmanager/-/web3-core-requestmanager-1.2.0.tgz",
-          "integrity": "sha512-hPe1jyESodXAiE7qJglu7ySo4GINCn5CgG+9G1ATLQbriZsir83QMSeKQekv/hckKFIf4SvZJRPEBhtAle+Dhw==",
-          "requires": {
-            "underscore": "1.9.1",
-            "web3-core-helpers": "1.2.0",
-            "web3-providers-http": "1.2.0",
-            "web3-providers-ipc": "1.2.0",
-            "web3-providers-ws": "1.2.0"
-          }
-        },
-        "web3-core-subscriptions": {
-          "version": "1.2.0",
-          "resolved": "https://registry.npmjs.org/web3-core-subscriptions/-/web3-core-subscriptions-1.2.0.tgz",
-          "integrity": "sha512-DHipGH8It5E4HxxvymhkudcYhBVgGx6MwGWobIVKFgp6JRxtuvAbqwrMbuD/+78J6yXOa4y9zVXBk12dm2NXGg==",
-          "requires": {
-            "eventemitter3": "3.1.2",
-            "underscore": "1.9.1",
-            "web3-core-helpers": "1.2.0"
-          }
-        },
-        "web3-eth": {
-          "version": "1.2.0",
-          "resolved": "https://registry.npmjs.org/web3-eth/-/web3-eth-1.2.0.tgz",
-          "integrity": "sha512-GP1+hHS/IVW1tAOIDS44PxCpvSl9PBU/KAB40WgP27UMvSy43LjHxGlP6hQQOdIfmBLBTvGvn2n+Z5kW2gzAzg==",
-          "requires": {
-            "underscore": "1.9.1",
-            "web3-core": "1.2.0",
-            "web3-core-helpers": "1.2.0",
-            "web3-core-method": "1.2.0",
-            "web3-core-subscriptions": "1.2.0",
-            "web3-eth-abi": "1.2.0",
-            "web3-eth-accounts": "1.2.0",
-            "web3-eth-contract": "1.2.0",
-            "web3-eth-ens": "1.2.0",
-            "web3-eth-iban": "1.2.0",
-            "web3-eth-personal": "1.2.0",
-            "web3-net": "1.2.0",
-            "web3-utils": "1.2.0"
-          }
-        },
-        "web3-eth-abi": {
-          "version": "1.2.0",
-          "resolved": "https://registry.npmjs.org/web3-eth-abi/-/web3-eth-abi-1.2.0.tgz",
-          "integrity": "sha512-FDuPq/tFeMg/D/f7cNSmvVYkMYb1z379gUUzSL8ZFtZrdHPkezq+lq/TmWmbCOMLYNXlhGJBzjGdLXRS4Upprg==",
-          "requires": {
-            "ethers": "4.0.0-beta.3",
-            "underscore": "1.9.1",
-            "web3-utils": "1.2.0"
-          }
-        },
-        "web3-eth-accounts": {
-          "version": "1.2.0",
-          "resolved": "https://registry.npmjs.org/web3-eth-accounts/-/web3-eth-accounts-1.2.0.tgz",
-          "integrity": "sha512-d/fUAL3F6HqstvEiBnZ1RwZ77/DytgF9d6A3mWVvPOUk2Pqi77PM0adRvsKvIWUaQ/k6OoCk/oXtbzaO7CyGpg==",
-          "requires": {
-            "any-promise": "1.3.0",
-            "crypto-browserify": "3.12.0",
-            "eth-lib": "0.2.7",
-            "scrypt.js": "^0.3.0",
-            "underscore": "1.9.1",
-            "uuid": "3.3.2",
-            "web3-core": "1.2.0",
-            "web3-core-helpers": "1.2.0",
-            "web3-core-method": "1.2.0",
-            "web3-utils": "1.2.0"
-          }
-        },
-        "web3-eth-contract": {
-          "version": "1.2.0",
-          "resolved": "https://registry.npmjs.org/web3-eth-contract/-/web3-eth-contract-1.2.0.tgz",
-          "integrity": "sha512-hfjozNbfsoMeR3QklfkwU0Mqcw6YRD4y1Cb1ghGWNhFy2+/sbvKcQNPPJDKFTde22PRzGQBWyh/nb422Sux4bQ==",
-          "requires": {
-            "underscore": "1.9.1",
-            "web3-core": "1.2.0",
-            "web3-core-helpers": "1.2.0",
-            "web3-core-method": "1.2.0",
-            "web3-core-promievent": "1.2.0",
-            "web3-core-subscriptions": "1.2.0",
-            "web3-eth-abi": "1.2.0",
-            "web3-utils": "1.2.0"
-          }
-        },
-        "web3-eth-ens": {
-          "version": "1.2.0",
-          "resolved": "https://registry.npmjs.org/web3-eth-ens/-/web3-eth-ens-1.2.0.tgz",
-          "integrity": "sha512-kE6uHMLwH9dv+MZSKT7BcKXcQ6CcLP5m5mM44s2zg2e9Rl20F3J6R3Ik6sLc/w2ywdCwTe/Z22yEstHXQwu5ig==",
-          "requires": {
-            "eth-ens-namehash": "2.0.8",
-            "underscore": "1.9.1",
-            "web3-core": "1.2.0",
-            "web3-core-helpers": "1.2.0",
-            "web3-core-promievent": "1.2.0",
-            "web3-eth-abi": "1.2.0",
-            "web3-eth-contract": "1.2.0",
-            "web3-utils": "1.2.0"
-          }
-        },
-        "web3-eth-iban": {
-          "version": "1.2.0",
-          "resolved": "https://registry.npmjs.org/web3-eth-iban/-/web3-eth-iban-1.2.0.tgz",
-          "integrity": "sha512-6DzTx/cvIgEvxadhJjLGpsuDUARA4RKskNOuwWYUsUODcPb50rsfMmRkHhGtLss/sNXVE5gNjbT9rX3TDqy2tg==",
-          "requires": {
-            "bn.js": "4.11.8",
-            "web3-utils": "1.2.0"
-          },
-          "dependencies": {
-            "bn.js": {
-              "version": "4.11.8",
-              "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.11.8.tgz",
-              "integrity": "sha512-ItfYfPLkWHUjckQCk8xC+LwxgK8NYcXywGigJgSwOP8Y2iyWT4f2vsZnoOXTTbo+o5yXmIUJ4gn5538SO5S3gA=="
-            }
-          }
-        },
-        "web3-eth-personal": {
-          "version": "1.2.0",
-          "resolved": "https://registry.npmjs.org/web3-eth-personal/-/web3-eth-personal-1.2.0.tgz",
-          "integrity": "sha512-8QdcaT6dbdiMC8zEqvDuij8XeI34r2GGdQYGvYBP2UgCm15EZBHgewxO30A+O+j2oIW1/Hu60zP5upnhCuA1Dw==",
-          "requires": {
-            "web3-core": "1.2.0",
-            "web3-core-helpers": "1.2.0",
-            "web3-core-method": "1.2.0",
-            "web3-net": "1.2.0",
-            "web3-utils": "1.2.0"
-          }
-        },
-        "web3-net": {
-          "version": "1.2.0",
-          "resolved": "https://registry.npmjs.org/web3-net/-/web3-net-1.2.0.tgz",
-          "integrity": "sha512-7iD8C6vvx8APXPMmlpPLGWjn4bsXHzd3BTdFzKjkoYjiiVFJdVAbY3j1BwN/6tVQu8Ay7sDpV2EdTNub7GKbyw==",
-          "requires": {
-            "web3-core": "1.2.0",
-            "web3-core-method": "1.2.0",
-            "web3-utils": "1.2.0"
-          }
-        },
-        "web3-providers-http": {
-          "version": "1.2.0",
-          "resolved": "https://registry.npmjs.org/web3-providers-http/-/web3-providers-http-1.2.0.tgz",
-          "integrity": "sha512-UrUn6JSz7NVCZ+0nZZtC4cmbl5JIi57w1flL1jN8jgkfdWDdErNvTkSwCt/QYdTQscMaUtWXDDOSAsVO6YC64g==",
-          "requires": {
-            "web3-core-helpers": "1.2.0",
-            "xhr2-cookies": "1.1.0"
-          }
-        },
-        "web3-providers-ipc": {
-          "version": "1.2.0",
-          "resolved": "https://registry.npmjs.org/web3-providers-ipc/-/web3-providers-ipc-1.2.0.tgz",
-          "integrity": "sha512-T2OSbiqu7+dahbGG5YFEQM5+FXdLVvaTCKmHXaQpw8IuL5hw7HELtyFOtHVudgDRyw0tJKxIfAiX/v2F1IL1fQ==",
-          "requires": {
-            "oboe": "2.1.4",
-            "underscore": "1.9.1",
-            "web3-core-helpers": "1.2.0"
-          }
-        },
-        "web3-providers-ws": {
-          "version": "1.2.0",
-          "resolved": "https://registry.npmjs.org/web3-providers-ws/-/web3-providers-ws-1.2.0.tgz",
-          "integrity": "sha512-rnwGcCe6cev5A6eG5UBCQqPmkJVZMCrK+HN1AvUCco0OHD/0asGc9LuLbtkQIyznA6Lzetq/OOcaTOM4KeT11g==",
-          "requires": {
-            "underscore": "1.9.1",
-            "web3-core-helpers": "1.2.0",
-            "websocket": "github:frozeman/WebSocket-Node#browserifyCompatible"
-          }
-        },
-        "web3-shh": {
-          "version": "1.2.0",
-          "resolved": "https://registry.npmjs.org/web3-shh/-/web3-shh-1.2.0.tgz",
-          "integrity": "sha512-VFjS8kvsQBodudFmIoVJWvDNZosONJZZnhvktngD3POu5dwbJmSCl6lzbLJ2C5XjR15dF+JvSstAkWbM+2sdPg==",
-          "requires": {
-            "web3-core": "1.2.0",
-            "web3-core-method": "1.2.0",
-            "web3-core-subscriptions": "1.2.0",
-            "web3-net": "1.2.0"
-          }
-        },
-        "web3-utils": {
-          "version": "1.2.0",
-          "resolved": "https://registry.npmjs.org/web3-utils/-/web3-utils-1.2.0.tgz",
-          "integrity": "sha512-tI1low8ICoaWU2c53cikH0rsksKuIskI2nycH5E5sEXxxl9/BOD3CeDDBFbxgNPQ+bpDevbR7gXNEDB7Ud4G9g==",
-          "requires": {
-            "bn.js": "4.11.8",
-            "eth-lib": "0.2.7",
-            "ethjs-unit": "0.1.6",
-            "number-to-bn": "1.7.0",
-            "randomhex": "0.1.5",
-            "underscore": "1.9.1",
-            "utf8": "3.0.0"
-          },
-          "dependencies": {
-            "bn.js": {
-              "version": "4.11.8",
-              "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.11.8.tgz",
-              "integrity": "sha512-ItfYfPLkWHUjckQCk8xC+LwxgK8NYcXywGigJgSwOP8Y2iyWT4f2vsZnoOXTTbo+o5yXmIUJ4gn5538SO5S3gA=="
-            }
-          }
-        },
-        "websocket": {
-          "version": "github:frozeman/WebSocket-Node#6c72925e3f8aaaea8dc8450f97627e85263999f2",
-          "from": "github:frozeman/WebSocket-Node#browserifyCompatible",
-          "requires": {
-            "debug": "^2.2.0",
-            "nan": "^2.3.3",
-            "typedarray-to-buffer": "^3.1.2",
-            "yaeti": "^0.0.6"
-          }
         }
       }
     },
     "@dorgtech/daocreator-ui-v1": {
-      "version": "0.2.0-rc.20",
-      "resolved": "https://registry.npmjs.org/@dorgtech/daocreator-ui-v1/-/daocreator-ui-v1-0.2.0-rc.20.tgz",
-      "integrity": "sha512-XnK57MplGMbicpPFQdIz7Goswg5cnjvEZ2nTf56Oau0ag9oujmMUUiqxeZylToI5cJNavz4FCIetUgQ4SuFrPA==",
+      "version": "1.0.0-beta.1",
+      "resolved": "https://registry.npmjs.org/@dorgtech/daocreator-ui-v1/-/daocreator-ui-v1-1.0.0-beta.1.tgz",
+      "integrity": "sha512-cF9dvzNGkjYX8icKvoztpNfzbhSutzYZHu8zTbC7OO/+yFEp2zk8YzUr946sxnqHG21RsJnNsDT30O8jJgW16g==",
       "requires": {
         "@date-io/core": "^1.3.6",
         "@date-io/date-fns": "^1.3.11",
@@ -2543,7 +2242,7 @@
         "@devexpress/dx-react-chart": "^2.0.2",
         "@devexpress/dx-react-chart-material-ui": "^2.0.2",
         "@devexpress/dx-react-core": "^2.0.2",
-        "@dorgtech/daocreator-lib": "0.2.1-rc.18",
+        "@dorgtech/daocreator-lib": "1.0.0-beta.1",
         "@material-ui/core": "^4.3.1",
         "@material-ui/icons": "^4.2.1",
         "@material-ui/pickers": "3.2.2",
@@ -3890,20 +3589,18 @@
       }
     },
     "@material-ui/core": {
-      "version": "4.9.1",
-      "resolved": "https://registry.npmjs.org/@material-ui/core/-/core-4.9.1.tgz",
-      "integrity": "sha512-wehQI0ahHDsZjK+uA8Q5Cs1K1/1HXYe2icwTqARaRCt7d9bTp0bJN/C9TLe/+sRWfRIkx6OIk7ABSJT1jBqxRg==",
+      "version": "4.9.5",
+      "resolved": "https://registry.npmjs.org/@material-ui/core/-/core-4.9.5.tgz",
+      "integrity": "sha512-hVuUqw6847jcgRsUqzCiYCXcIJYhPUfM3gS9sNehTsbI0SF3tufLNO2B2Cgkuns8uOGy0nicD4p3L7JqhnEElg==",
       "requires": {
         "@babel/runtime": "^7.4.4",
         "@material-ui/styles": "^4.9.0",
-        "@material-ui/system": "^4.9.1",
+        "@material-ui/system": "^4.9.3",
         "@material-ui/types": "^5.0.0",
         "@material-ui/utils": "^4.7.1",
         "@types/react-transition-group": "^4.2.0",
         "clsx": "^1.0.2",
-        "convert-css-length": "^2.0.1",
         "hoist-non-react-statics": "^3.3.2",
-        "normalize-scroll-left": "^0.2.0",
         "popper.js": "^1.14.1",
         "prop-types": "^15.7.2",
         "react-is": "^16.8.0",
@@ -3911,9 +3608,9 @@
       },
       "dependencies": {
         "@types/react-transition-group": {
-          "version": "4.2.3",
-          "resolved": "https://registry.npmjs.org/@types/react-transition-group/-/react-transition-group-4.2.3.tgz",
-          "integrity": "sha512-Hk8jiuT7iLOHrcjKP/ZVSyCNXK73wJAUz60xm0mVhiRujrdiI++j4duLiL282VGxwAgxetHQFfqA29LgEeSkFA==",
+          "version": "4.2.4",
+          "resolved": "https://registry.npmjs.org/@types/react-transition-group/-/react-transition-group-4.2.4.tgz",
+          "integrity": "sha512-8DMUaDqh0S70TjkqU0DxOu80tFUiiaS9rxkWip/nb7gtvAsbqOXm02UCmR8zdcjWujgeYPiPNTVpVpKzUDotwA==",
           "requires": {
             "@types/react": "*"
           }
@@ -4007,9 +3704,9 @@
       }
     },
     "@material-ui/system": {
-      "version": "4.9.1",
-      "resolved": "https://registry.npmjs.org/@material-ui/system/-/system-4.9.1.tgz",
-      "integrity": "sha512-CLrJK2aKNWNwruGVTRf+rLz96P4jmozpY2UaCE6hBTa1oGsQ396YXOQQABQ4c0igawmdyf5iQb0zs9j5zsAf1w==",
+      "version": "4.9.3",
+      "resolved": "https://registry.npmjs.org/@material-ui/system/-/system-4.9.3.tgz",
+      "integrity": "sha512-DBGsTKYrLlFpHG8BUp0X6ZpvaOzef+GhSwn/8DwVTXUdHitphaPQoL9xucrI8X9MTBo//El+7nylko7lo7eJIw==",
       "requires": {
         "@babel/runtime": "^7.4.4",
         "@material-ui/utils": "^4.7.1",
@@ -8714,8 +8411,7 @@
     "arrify": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/arrify/-/arrify-1.0.1.tgz",
-      "integrity": "sha1-iYUI2iIm84DfkEcoRWhJwVAaSw0=",
-      "dev": true
+      "integrity": "sha1-iYUI2iIm84DfkEcoRWhJwVAaSw0="
     },
     "asap": {
       "version": "2.0.6",
@@ -11841,11 +11537,6 @@
       "resolved": "https://registry.npmjs.org/content-type/-/content-type-1.0.4.tgz",
       "integrity": "sha512-hIP3EEPs8tB9AT1L+NUqtwOAps4mk2Zob89MWXMHjHWg9milF/j4osnnQLXBCBFBk/tvIG/tUc9mOUJiPBhPXA=="
     },
-    "convert-css-length": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/convert-css-length/-/convert-css-length-2.0.1.tgz",
-      "integrity": "sha512-iGpbcvhLPRKUbBc0Quxx7w/bV14AC3ItuBEGMahA5WTYqB8lq9jH0kTXFheCBASsYnqeMFZhiTruNxr1N59Axg=="
-    },
     "convert-source-map": {
       "version": "1.7.0",
       "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.7.0.tgz",
@@ -12783,13 +12474,13 @@
       "integrity": "sha512-msVS9qTuMT5zwAGCVm4mxfrZ18BNc6Csd0oJAtiFMZ1FAx1CCvy2+5MDmYoix63LM/6NDbNtodCiGYGmFgO0dA=="
     },
     "csv": {
-      "version": "5.3.1",
-      "resolved": "https://registry.npmjs.org/csv/-/csv-5.3.1.tgz",
-      "integrity": "sha512-UBO4x5EYpihikfjHUQ7dCTIgC+e9TrWWZbCcoMr935tcAZfXT1MZKHLD+aYSHs1jwW2G1uljpFfJ4XxYwQ6t5w==",
+      "version": "5.3.2",
+      "resolved": "https://registry.npmjs.org/csv/-/csv-5.3.2.tgz",
+      "integrity": "sha512-odDyucr9OgJTdGM2wrMbJXbOkJx3nnUX3Pt8SFOwlAMOpsUQlz1dywvLMXJWX/4Ib0rjfOsaawuuwfI5ucqBGQ==",
       "requires": {
         "csv-generate": "^3.2.4",
-        "csv-parse": "^4.8.2",
-        "csv-stringify": "^5.3.4",
+        "csv-parse": "^4.8.8",
+        "csv-stringify": "^5.3.6",
         "stream-transform": "^2.0.1"
       }
     },
@@ -12799,9 +12490,9 @@
       "integrity": "sha512-qNM9eqlxd53TWJeGtY1IQPj90b563Zx49eZs8e0uMyEvPgvNVmX1uZDtdzAcflB3PniuH9creAzcFOdyJ9YGvA=="
     },
     "csv-parse": {
-      "version": "4.8.5",
-      "resolved": "https://registry.npmjs.org/csv-parse/-/csv-parse-4.8.5.tgz",
-      "integrity": "sha512-rpsLmlLWJZifmLzZEVGbZ9phWnJyi+cCbCGYr4vX2NaHFtgbmQPFk+WmMkmMkQXgsIUn6CgnK9cTuUAfFjoXbA=="
+      "version": "4.8.8",
+      "resolved": "https://registry.npmjs.org/csv-parse/-/csv-parse-4.8.8.tgz",
+      "integrity": "sha512-Kv3Ilz2GV58dOoHBXRCTF8ijxlLjl80bG3d67XPI6DNqffb3AnbPbKr/WvCUMJq5V0AZYi6sukOaOQAVpfuVbg=="
     },
     "csv-stringify": {
       "version": "5.3.6",
@@ -13575,8 +13266,7 @@
     "diff": {
       "version": "3.5.0",
       "resolved": "https://registry.npmjs.org/diff/-/diff-3.5.0.tgz",
-      "integrity": "sha512-A46qtFgd+g7pDZinpnwiRJtxbC1hpgf0uzP3iG89scHk0AUC7A1TGxf5OiiOUv/JMZR8GOt8hL900hV0bOy5xA==",
-      "dev": true
+      "integrity": "sha512-A46qtFgd+g7pDZinpnwiRJtxbC1hpgf0uzP3iG89scHk0AUC7A1TGxf5OiiOUv/JMZR8GOt8hL900hV0bOy5xA=="
     },
     "diff-sequences": {
       "version": "24.9.0",
@@ -25665,8 +25355,7 @@
     "make-error": {
       "version": "1.3.5",
       "resolved": "https://registry.npmjs.org/make-error/-/make-error-1.3.5.tgz",
-      "integrity": "sha512-c3sIjNUow0+8swNwVpqoH4YCShKNFkMaw6oH1mNS2haDZQqkeZFlHS3dhoeEbKKmJB4vXpJucU6oH75aDYeE9g==",
-      "dev": true
+      "integrity": "sha512-c3sIjNUow0+8swNwVpqoH4YCShKNFkMaw6oH1mNS2haDZQqkeZFlHS3dhoeEbKKmJB4vXpJucU6oH75aDYeE9g=="
     },
     "makeerror": {
       "version": "1.0.11",
@@ -25749,9 +25438,9 @@
       }
     },
     "material-ui-popup-state": {
-      "version": "1.5.1",
-      "resolved": "https://registry.npmjs.org/material-ui-popup-state/-/material-ui-popup-state-1.5.1.tgz",
-      "integrity": "sha512-UkCbn3H8U602zpYY/mlYdoT8JVqSB5CT022uDmRvjNS0hrtQ98Qxb6JyeVMvEM8YrAA2E8jIFDGCovWCZ40Dcg==",
+      "version": "1.5.3",
+      "resolved": "https://registry.npmjs.org/material-ui-popup-state/-/material-ui-popup-state-1.5.3.tgz",
+      "integrity": "sha512-Nz0S817nYioLugxOTfxcuz4l8dZpGEz4QTKDLeLwR53jxKfwUowHUFVI6Eg/RaYEujGaCRapfpxGoTwWRFTCdw==",
       "requires": {
         "@babel/runtime": "^7.1.5",
         "@material-ui/types": "^4.1.1",
@@ -26411,9 +26100,9 @@
       "integrity": "sha512-xRFJxSU2Im3nrGCdjSuOTFmxVDGeqOHL+TyADCGbT0k4HHqGmx5u2yaHNryvoORpI4DfbzjJ5jPmuv+d7sioFw=="
     },
     "mobx-react": {
-      "version": "6.1.6",
-      "resolved": "https://registry.npmjs.org/mobx-react/-/mobx-react-6.1.6.tgz",
-      "integrity": "sha512-1HjHkUKhvrFz0JvgaTHPHw0oCWvlM7EtMp1KlCiUaf6rY/JW855pKlQrkBJWXNqS+YvOEksiD8bfEyqp9ep8IQ==",
+      "version": "6.1.8",
+      "resolved": "https://registry.npmjs.org/mobx-react/-/mobx-react-6.1.8.tgz",
+      "integrity": "sha512-NCMJn/hrWoeyeNbzCsBDtftWSy6VlFgw1VzhogrciPFvJIl2xs+8rJJdPlRHQTiNirwNoHNKJgUE4WhPZPvKDw==",
       "requires": {
         "mobx-react-lite": "^1.4.2"
       }
@@ -27162,11 +26851,6 @@
       "resolved": "https://registry.npmjs.org/normalize-range/-/normalize-range-0.1.2.tgz",
       "integrity": "sha1-LRDAa9/TEuqXd2laTShDlFa3WUI=",
       "dev": true
-    },
-    "normalize-scroll-left": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/normalize-scroll-left/-/normalize-scroll-left-0.2.0.tgz",
-      "integrity": "sha512-t5oCENZJl8TGusJKoCJm7+asaSsPuNmK6+iEjrZ5TyBj2f02brCRsd4c83hwtu+e5d4LCSBZ0uoDlMjBo+A8yA=="
     },
     "normalize-url": {
       "version": "4.5.0",
@@ -32295,7 +31979,8 @@
     "randomhex": {
       "version": "0.1.5",
       "resolved": "https://registry.npmjs.org/randomhex/-/randomhex-0.1.5.tgz",
-      "integrity": "sha1-us7vmCMpCRQA8qKRLGzQLxCU9YU="
+      "integrity": "sha1-us7vmCMpCRQA8qKRLGzQLxCU9YU=",
+      "dev": true
     },
     "range-parser": {
       "version": "1.2.1",
@@ -34426,6 +34111,7 @@
       "version": "6.0.3",
       "resolved": "https://registry.npmjs.org/scrypt/-/scrypt-6.0.3.tgz",
       "integrity": "sha1-BOAUpWgrU/pQwtXM4WfXGcBthw0=",
+      "dev": true,
       "requires": {
         "nan": "^2.0.8"
       }
@@ -34439,6 +34125,7 @@
       "version": "0.3.0",
       "resolved": "https://registry.npmjs.org/scrypt.js/-/scrypt.js-0.3.0.tgz",
       "integrity": "sha512-42LTc1nyFsyv/o0gcHtDztrn+aqpkaCNt5Qh7ATBZfhEZU7IC/0oT/qbBH+uRNoAPvs2fwiOId68FDEoSRA8/A==",
+      "dev": true,
       "requires": {
         "scrypt": "^6.0.2",
         "scryptsy": "^1.2.1"
@@ -34448,6 +34135,7 @@
           "version": "1.2.1",
           "resolved": "https://registry.npmjs.org/scryptsy/-/scryptsy-1.2.1.tgz",
           "integrity": "sha1-oyJfpLJST4AnAHYeKFW987LZIWM=",
+          "dev": true,
           "requires": {
             "pbkdf2": "^3.0.3"
           }
@@ -37455,7 +37143,6 @@
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/ts-node/-/ts-node-5.0.1.tgz",
       "integrity": "sha512-XK7QmDcNHVmZkVtkiwNDWiERRHPyU8nBqZB1+iv2UhOG0q3RQ9HsZ2CMqISlFbxjrYFGfG2mX7bW4dAyxBVzUw==",
-      "dev": true,
       "requires": {
         "arrify": "^1.0.0",
         "chalk": "^2.3.0",
@@ -37471,7 +37158,6 @@
           "version": "3.2.1",
           "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
           "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
-          "dev": true,
           "requires": {
             "color-convert": "^1.9.0"
           }
@@ -37480,7 +37166,6 @@
           "version": "2.4.2",
           "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
           "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
-          "dev": true,
           "requires": {
             "ansi-styles": "^3.2.1",
             "escape-string-regexp": "^1.0.5",
@@ -37490,14 +37175,12 @@
         "minimist": {
           "version": "1.2.0",
           "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
-          "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
-          "dev": true
+          "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ="
         },
         "mkdirp": {
           "version": "0.5.1",
           "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
           "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
-          "dev": true,
           "requires": {
             "minimist": "0.0.8"
           },
@@ -37505,22 +37188,19 @@
             "minimist": {
               "version": "0.0.8",
               "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
-              "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
-              "dev": true
+              "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0="
             }
           }
         },
         "source-map": {
           "version": "0.6.1",
           "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-          "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
-          "dev": true
+          "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="
         },
         "source-map-support": {
           "version": "0.5.16",
           "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.16.tgz",
           "integrity": "sha512-efyLRJDr68D9hBBNIPWFjhpFzURh+KJykQwvMyW5UiZzYwoF6l4YMMDIJJEyFWxWCqfyxLzz6tSfUFR+kXXsVQ==",
-          "dev": true,
           "requires": {
             "buffer-from": "^1.0.0",
             "source-map": "^0.6.0"
@@ -37530,7 +37210,6 @@
           "version": "5.5.0",
           "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
           "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
-          "dev": true,
           "requires": {
             "has-flag": "^3.0.0"
           }
@@ -40174,8 +39853,7 @@
     "yn": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/yn/-/yn-2.0.0.tgz",
-      "integrity": "sha1-5a2ryKz0CPY4X8dklWhMiOavaJo=",
-      "dev": true
+      "integrity": "sha1-5a2ryKz0CPY4X8dklWhMiOavaJo="
     },
     "zcash-bitcore-lib": {
       "version": "0.13.20-rc3",

--- a/package.json
+++ b/package.json
@@ -78,7 +78,7 @@
     "3box": "^1.16.1",
     "@burner-wallet/burner-connect-provider": "^0.1.1",
     "@daostack/client": "0.2.64",
-    "@dorgtech/daocreator-ui-v1": "^0.2.0-rc.20",
+    "@dorgtech/daocreator-ui-v1": "^1.0.0-beta.1",
     "@fortawesome/fontawesome-svg-core": "^1.2.10",
     "@fortawesome/free-brands-svg-icons": "^5.6.1",
     "@fortawesome/react-fontawesome": "^0.1.3",


### PR DESCRIPTION
The fix needed was to upgrade the `web3` dependency DAOcreator's Lib uses to 1.2.4. The old version included a `preInstall` script that used the `rm` unix command.