### PR TITLE
Add CO2ken scheme and corresponding proposal summary custom UI

### DIFF
--- a/src/components/Proposal/ProposalSummary/ProposalSummaryCO2ken.tsx
+++ b/src/components/Proposal/ProposalSummary/ProposalSummaryCO2ken.tsx
@@ -1,0 +1,164 @@
+import { IProposalState } from "@daostack/client";
+
+import classNames from "classnames";
+import { GenericSchemeInfo } from "genericSchemeRegistry";
+import * as React from "react";
+import * as css from "./ProposalSummary.scss";
+
+interface IProps {
+  genericSchemeInfo: GenericSchemeInfo;
+  detailView?: boolean;
+  proposal: IProposalState;
+  transactionModal?: boolean;
+}
+
+export default class ProposalSummaryCO2ken extends React.Component<IProps, null> {
+
+  public render(): RenderOutput {
+    const { proposal, detailView, genericSchemeInfo, transactionModal } = this.props;
+    let decodedCallData: any;
+    try {
+      decodedCallData = genericSchemeInfo.decodeCallData(proposal.genericScheme.callData);
+    } catch(err) {
+      if (err.message.match(/no action matching/gi)) {
+        return <div>Error: {err.message} </div>;
+      } else {
+        throw err;
+      }
+    }
+    const action = decodedCallData.action;
+
+    const proposalSummaryClass = classNames({
+      [css.detailView]: detailView,
+      [css.transactionModal]: transactionModal,
+      [css.proposalSummary]: true,
+      [css.withDetails]: true,
+    });
+
+    switch (action.id) {
+      case "mint": {
+        const ipfsHashValue = decodedCallData.values[0];
+        const amountTokensValue = decodedCallData.values[1];
+        return (
+          <div className={proposalSummaryClass}>
+            <span className={css.summaryTitle}>
+              {action.label}
+            </span>
+            { detailView ?
+              <div className={css.summaryDetails}>
+                <div>
+                  <p>
+                    Executing this proposal will mint a total of:
+                    <pre>{amountTokensValue} new CO2kens</pre>
+                  </p>
+                  <p>
+                    Before voting on this proposal, verify that the passed IPFS hash is a valid certificate.
+                    Click on the hash below to see the certificate:
+                    <pre>
+                      <a href={`https://cloudflare-ipfs.com/ipfs/${ipfsHashValue}`} target="_blank" rel="noopener noreferrer">{ipfsHashValue}</a>
+                    </pre>
+                  </p>
+                </div>
+              </div>
+              : ""
+            }
+          </div>
+        );
+      }
+      case "approve":
+        return (
+          <div className={proposalSummaryClass}>
+            <span className={css.summaryTitle}>
+              {action.label}
+            </span>
+            {detailView ?
+              <div className={css.summaryDetails}>
+                Executing this proposal will call the function
+                <pre>{action.id}()</pre>
+                with value
+                <pre>{-1}</pre>
+                It allows the the CO2ken contract to move DAI held by the DAO. This way, the DAO can offset its emissions by calling:
+                <pre>offsetCarbon()</pre>
+              </div>
+              : ""
+            }
+          </div>
+        );
+      case "withdraw":
+        return (
+          <div className={proposalSummaryClass}>
+            <span className={css.summaryTitle}>
+              {action.label}
+            </span>
+            {detailView ?
+              <div className={css.summaryDetails}>
+                Executing this proposal will call the function
+                <pre>{action.id}()</pre>
+                It transfers all the DAI stored in the CO2ken contract to the DAO.
+              </div>
+              : ""
+            }
+          </div>
+        );
+      case "offsetCarbon":
+        return (
+          <div className={proposalSummaryClass}>
+            <span className={css.summaryTitle}>
+              {action.label}
+            </span>
+            {detailView ?
+              <div className={css.summaryDetails}>
+                Executing this proposal will call the function
+                <pre>{action.id}()</pre>
+                with value
+                <pre>{decodedCallData.values[0]}</pre>
+                The value describes the amount of DAI (with 18 decimals) that are sent to the CO2ken contract to offset a relative amount of the DAO‘s carbon emissions.
+              </div>
+              : ""
+            }
+          </div>
+        );
+      case "offsetCarbonTons":
+      {
+        return (
+          <div className={proposalSummaryClass}>
+            <span className={css.summaryTitle}>
+              {action.label}
+            </span>
+            {detailView ?
+              <div className={css.summaryDetails}>
+                Executing this proposal will call the function
+                <pre>{action.id}()</pre>
+                with value
+                <pre>{decodedCallData.values[0]}</pre>
+                The value describes the amount of carbon tons (with 18 decimals) the DAO wants to offset.
+              </div>
+              : ""
+            }
+          </div>
+        );
+      }
+      case "transferOwnership":
+      {
+        return (
+          <div className={proposalSummaryClass}>
+            <span className={css.summaryTitle}>
+              {action.label}
+            </span>
+            {detailView ?
+              <div className={css.summaryDetails}>
+                Executing this proposal will call the function
+                <pre>{action.id}()</pre>
+                with the new owner‘s address being
+                <pre>{decodedCallData.values[0]}</pre>
+              </div>
+              : ""
+            }
+          </div>
+        );
+      }
+      default:
+        return "";
+    }
+  }
+}

--- a/src/components/Proposal/ProposalSummary/ProposalSummaryKnownGenericScheme.tsx
+++ b/src/components/Proposal/ProposalSummary/ProposalSummaryKnownGenericScheme.tsx
@@ -7,6 +7,7 @@ import { IProfileState } from "reducers/profilesReducer";
 import * as css from "./ProposalSummary.scss";
 import ProposalSummaryDutchX from "./ProposalSummaryDutchX";
 import ProposalSummaryStandardBounties from "./ProposalSummaryStandardBounties";
+import ProposalSummaryCO2ken from "./ProposalSummaryCO2ken";
 
 interface IProps {
   beneficiaryProfile?: IProfileState;
@@ -33,6 +34,8 @@ export default class ProposalSummary extends React.Component<IProps> {
       return <ProposalSummaryDutchX {...this.props} />;
     } else if (genericSchemeInfo.specs.name === "Standard Bounties") {
       return <ProposalSummaryStandardBounties {...this.props} />;
+    } else if(genericSchemeInfo.specs.name === "CO2ken") {
+      return <ProposalSummaryCO2ken {...this.props} />;
     }
     const proposalSummaryClass = classNames({
       [css.detailView]: detailView,

--- a/src/genericSchemeRegistry/index.ts
+++ b/src/genericSchemeRegistry/index.ts
@@ -11,9 +11,11 @@ const ensRegistrarInfo = require("./schemes/EnsRegistrar.json");
 const ensRegistryInfo = require("./schemes/ENSRegistry.json");
 const ensPublicResolverInfo = require("./schemes/ENSPublicResolver.json");
 const registryLookupInfo = require("./schemes/RegistryLookup.json");
+const co2kenInfo = require("./schemes/CO2ken.json");
 
 const KNOWNSCHEMES = [
   dutchXInfo,
+  co2kenInfo,
   bountiesInfo,
   ensRegistrarInfo,
   ensRegistryInfo,

--- a/src/genericSchemeRegistry/schemes/CO2ken.json
+++ b/src/genericSchemeRegistry/schemes/CO2ken.json
@@ -1,0 +1,167 @@
+{
+    "name": "CO2ken",
+    "addresses": {
+      "main": [
+        ""
+      ],
+      "rinkeby": [
+        "0x93Ec2167Da2A83fbBE61567F67F71750C13B9C09"
+      ],
+      "private": [
+        ""
+      ]
+    },
+    "actions": [
+      {
+        "id": "mint",
+        "label": "Mint new CO2kens",
+        "description": "One CO2ken represents 1 negative tonne of carbon. New CO2kens can be created by providing proof that an equivalent amount of carbon offsets have been purchased. An IPFS hash to this proof has to be provided when making this proposal.",
+        "notes": "https://github.com/CO2ken/CO2ken/blob/master/Contracts/co2ken.sol",
+        "fields": [
+          {
+            "label": "IPFS hash",
+            "name": "ipfsHash",
+            "placeholder": "Hash (QmafjwN...)"
+          },
+          {
+            "label": "Number of CO2kens to be minted",
+            "name": "amountTokens",
+            "placeholder": "Input number of CO2kens"
+          }
+        ],
+        "abi": {
+          "constant": false,
+          "inputs": [
+            {
+              "name": "ipfsHash",
+              "type": "string"
+            },
+            {
+              "name": "amountTokens",
+              "type": "uint256"
+            }
+          ],
+          "name": "mint",
+          "outputs": [],
+          "payable": false,
+          "stateMutability": "nonpayable",
+          "type": "function"
+        }
+      },
+      {
+        "id": "approve",
+        "label": "Approve DAI movement",
+        "description": "Allows the CO2ken contract to move your DAI for you.",
+        "notes": "https://github.com/CO2ken/CO2ken/blob/master/Contracts/co2ken.sol",
+        "fields": [],
+        "abi": {
+          "constant": false,
+          "inputs": [],
+          "name": "approve",
+          "outputs": [],
+          "payable": false,
+          "stateMutability": "nonpayable",
+          "type": "function"
+        }
+      },
+      {
+        "id": "withdraw",
+        "label": "Withdraw DAI",
+        "description": "Withdraw the DAI funds stored in the CO2ken contract to the CarbonDAO wallet address.",
+        "notes": "https://github.com/CO2ken/CO2ken/blob/master/Contracts/co2ken.sol",
+        "fields": [],
+        "abi": {
+          "constant": false,
+          "inputs": [],
+          "name": "withdraw",
+          "outputs": [],
+          "payable": false,
+          "stateMutability": "nonpayable",
+          "type": "function"
+        }
+      },
+      {
+        "id": "offsetCarbon",
+        "label": "Offset emissions with DAI",
+        "description": "Send DAI to retire CO2kens and offset your carbon footprint.",
+        "notes": "https://github.com/CO2ken/CO2ken/blob/master/Contracts/co2ken.sol",
+        "fields": [
+          {
+            "decimals": 18,
+            "label": "DAI to spend",
+            "name": "payment",
+            "unit": "DAI",
+            "placeholder": "Amount of DAI (20)"
+          }
+        ],
+        "abi": {
+          "constant": false,
+          "inputs": [
+            {
+              "name": "payment",
+              "type": "uint256"
+            }
+          ],
+          "name": "offsetCarbon",
+          "outputs": [],
+          "payable": false,
+          "stateMutability": "nonpayable",
+          "type": "function"
+        }
+      },
+      {
+        "id": "offsetCarbonTons",
+        "label": "Offset emissions in tons of CO2",
+        "description": "Indicate how many tonnes of CO2 emissions you want to offset. An equivalent amount of CO2kens will be retired.",
+        "notes": "https://github.com/CO2ken/CO2ken/blob/master/Contracts/co2ken.sol",
+        "fields": [
+            {
+            "label": "Tons of CO2 to be offset",
+            "name": "tons",
+            "placeholder": "CO2 emissions in tons (2)"
+            }
+        ],
+        "abi": {
+          "constant": false,
+          "inputs": [
+            {
+              "name": "tons",
+              "type": "uint256"
+            }
+          ],
+          "name": "offsetCarbonTons",
+          "outputs": [],
+          "payable": false,
+          "stateMutability": "nonpayable",
+          "type": "function"
+        }
+      },
+      {
+        "id": "transferOwnership",
+        "label": "Transfer ownership",
+        "description": "Transfer the owernship of the CO2ken contract to a new address.",
+        "notes": "https://github.com/gnosis/dx-contracts/blob/master/contracts/base/EthOracle.sol",
+        "fields": [
+          {
+            "label": "New owner's adddress",
+            "name": "newOwner",
+            "placeholder": "Address (0x0000…)"
+          }
+        ],
+        "abi": {
+          "constant": false,
+          "inputs": [
+            {
+              "name": "newOwner",
+              "type": "address"
+            }
+          ],
+          "name": "transferOwnership",
+          "outputs": [],
+          "payable": false,
+          "stateMutability": "nonpayable",
+          "type": "function"
+        }
+      }
+    ]
+  }


### PR DESCRIPTION
These changes have been made under the guidance of Jordan Ellis (@dOrgJelli).

We have deployed a new DAO on DAOStack called CarbonDAO (currently on Rinkeby at `0xc9a37828f16649fb3f578e3cc4968fbd46c301ac`).

This commit provides a custom UI for our custom `CO2ken.sol` contract which can be found at https://github.com/CO2ken/CO2ken/tree/master/Contracts (Rinkeby address: `0x93Ec2167Da2A83fbBE61567F67F71750C13B9C09`).

Our DAO tokenizes carbon offsets based on certificates purchased from carbon offset retailers.
When minting new tokens, a hash to the certificates stored on IPFS has to be provided. 
To be able to include a link to these certificates in a new proposal we had to change the generic scheme proposal UI.

You can read more about the project at:

  - https://medium.com/curve-labs/co2ken-genesis-74d7a1387ea1
  - https://co2ken.io