### PR TITLE
Add OmenDisputeResolution Generic Scheme

### DIFF
--- a/src/components/Proposal/ProposalSummary/ProposalSummaryKnownGenericScheme.tsx
+++ b/src/components/Proposal/ProposalSummary/ProposalSummaryKnownGenericScheme.tsx
@@ -8,6 +8,7 @@ import * as css from "./ProposalSummary.scss";
 import ProposalSummaryDutchX from "./ProposalSummaryDutchX";
 import ProposalSummaryStandardBounties from "./ProposalSummaryStandardBounties";
 import ProposalSummaryCO2ken from "./ProposalSummaryCO2ken";
+import ProposalSummaryOmenDisputeResolution from "./ProposalSummaryOmenDisputeResolution";
 
 interface IProps {
   beneficiaryProfile?: IProfileState;
@@ -36,6 +37,8 @@ export default class ProposalSummary extends React.Component<IProps> {
       return <ProposalSummaryStandardBounties {...this.props} />;
     } else if(genericSchemeInfo.specs.name === "CO2ken") {
       return <ProposalSummaryCO2ken {...this.props} />;
+    } else if (genericSchemeInfo.specs.name === "Omen Dispute Resolution") {
+      return <ProposalSummaryOmenDisputeResolution {...this.props} />;
     }
     const proposalSummaryClass = classNames({
       [css.detailView]: detailView,

--- a/src/components/Proposal/ProposalSummary/ProposalSummaryOmenDisputeResolution.tsx
+++ b/src/components/Proposal/ProposalSummary/ProposalSummaryOmenDisputeResolution.tsx
@@ -1,0 +1,73 @@
+import { IProposalState } from "@daostack/client";
+import classNames from "classnames";
+import { GenericSchemeInfo } from "genericSchemeRegistry";
+import { linkToEtherScan } from "lib/util";
+import * as React from "react";
+import * as css from "./ProposalSummary.scss";
+
+interface IProps {
+  genericSchemeInfo: GenericSchemeInfo;
+  detailView?: boolean;
+  proposal: IProposalState;
+  transactionModal?: boolean;
+}
+
+
+export default class ProposalSummaryOmenDisputeResolution extends React.Component<IProps, null> {
+
+  private inputHtml = (x: any) => <span key={x.name}>{x.name} {x.type}, </span>;
+  private callDataHtml = (value: any) => <div key={value}>{value}</div>;
+
+  public render(): RenderOutput {
+    const { proposal, detailView, genericSchemeInfo, transactionModal } = this.props;
+    let decodedCallData: any;
+    try {
+      decodedCallData = genericSchemeInfo.decodeCallData(proposal.genericScheme.callData);
+    } catch(err) {
+      if (err.message.match(/no action matching/gi)) {
+        return <div>Error: {err.message} </div>;
+      } else {
+        throw err;
+      }
+    }
+    
+    const action = decodedCallData.action;
+
+    const proposalSummaryClass = classNames({
+      [css.detailView]: detailView,
+      [css.transactionModal]: transactionModal,
+      [css.proposalSummary]: true,
+      [css.withDetails]: true,
+    });
+
+    switch (action.id) {
+      case "disputeRequestNotification":
+        return <div className={proposalSummaryClass}>
+        <span className={css.summaryTitle}>
+          <img src="/assets/images/Icon/edit-sm.svg"/>&nbsp;
+          { decodedCallData.action.label }
+        </span>
+      </div>;
+      default:
+        return <div className={proposalSummaryClass}>
+          <span className={css.summaryTitle}>
+            <img src="/assets/images/Icon/edit-sm.svg"/>&nbsp;
+            { decodedCallData.action.label }
+          </span>
+
+          {detailView ?
+            <div className={css.summaryDetails}>
+              Executing this proposal will call the function
+              <pre>{ decodedCallData.action.abi.name}
+            ({ decodedCallData.action.abi.inputs.map(this.inputHtml) })
+              </pre>
+              with values <pre>{ decodedCallData.values.map(this.callDataHtml)}</pre>
+              on contract at
+              <pre><a href={linkToEtherScan(proposal.genericScheme.contractToCall)}>{proposal.genericScheme.contractToCall}</a></pre>
+            </div>
+            : ""
+          }
+        </div>;
+    }
+  }
+}

--- a/src/components/Proposal/ProposalSummary/ProposalSummaryOmenDisputeResolution.tsx
+++ b/src/components/Proposal/ProposalSummary/ProposalSummaryOmenDisputeResolution.tsx
@@ -32,6 +32,7 @@ export default class ProposalSummaryOmenDisputeResolution extends React.Componen
     }
     
     const action = decodedCallData.action;
+    const realitioQuestionId = decodedCallData.values[0];
 
     const proposalSummaryClass = classNames({
       [css.detailView]: detailView,
@@ -42,7 +43,6 @@ export default class ProposalSummaryOmenDisputeResolution extends React.Componen
 
     switch (action.id) {
       case "disputeRequestNotification":
-        const realitioQuestionId = decodedCallData.values[0];
         return <div className={proposalSummaryClass}>
           <span className={css.summaryTitle}>
             <img src="/assets/images/Icon/edit-sm.svg"/>&nbsp;

--- a/src/components/Proposal/ProposalSummary/ProposalSummaryOmenDisputeResolution.tsx
+++ b/src/components/Proposal/ProposalSummary/ProposalSummaryOmenDisputeResolution.tsx
@@ -17,7 +17,6 @@ export default class ProposalSummaryOmenDisputeResolution extends React.Componen
 
   private inputHtml = (x: any) => <span key={x.name}>{x.name} {x.type}, </span>;
   private callDataHtml = (value: any) => <div key={value}>{value}</div>;
-  private callDataValue = (value: any) => {value};
 
   public render(): RenderOutput {
     const { proposal, detailView, genericSchemeInfo, transactionModal } = this.props;
@@ -43,6 +42,7 @@ export default class ProposalSummaryOmenDisputeResolution extends React.Componen
 
     switch (action.id) {
       case "disputeRequestNotification":
+        const realitioQuestionId = decodedCallData.values[0];
         return <div className={proposalSummaryClass}>
           <span className={css.summaryTitle}>
             <img src="/assets/images/Icon/edit-sm.svg"/>&nbsp;
@@ -51,7 +51,7 @@ export default class ProposalSummaryOmenDisputeResolution extends React.Componen
 
           {detailView ?
             <div className={css.summaryDetails}>
-              Requested from realit.io QuestionId: <a href={`https://realitio.github.io/#!/question/${decodedCallData.values.map(this.callDataValue)}` }>{ decodedCallData.values.map(this.callDataHtml)}</a>
+              Requested from realit.io QuestionId: <a href={`https://realitio.github.io/#!/question/${realitioQuestionId}`}>{ decodedCallData.values.map(this.callDataHtml)}</a>
             </div>
             : ""
           }

--- a/src/components/Proposal/ProposalSummary/ProposalSummaryOmenDisputeResolution.tsx
+++ b/src/components/Proposal/ProposalSummary/ProposalSummaryOmenDisputeResolution.tsx
@@ -50,7 +50,7 @@ export default class ProposalSummaryOmenDisputeResolution extends React.Componen
 
           {detailView ?
             <div className={css.summaryDetails}>
-              Requested from realit.io QuestionId: { decodedCallData.values.map(this.callDataHtml)}
+              Requested from realit.io QuestionId: <a href={"https://realitio.github.io/#!/question/"+decodedCallData.values.map(this.callDataHtml)}>{ decodedCallData.values.map(this.callDataHtml)}</a>
             </div>
             : ""
           }

--- a/src/components/Proposal/ProposalSummary/ProposalSummaryOmenDisputeResolution.tsx
+++ b/src/components/Proposal/ProposalSummary/ProposalSummaryOmenDisputeResolution.tsx
@@ -43,11 +43,11 @@ export default class ProposalSummaryOmenDisputeResolution extends React.Componen
     switch (action.id) {
       case "disputeRequestNotification":
         return <div className={proposalSummaryClass}>
-        <span className={css.summaryTitle}>
-          <img src="/assets/images/Icon/edit-sm.svg"/>&nbsp;
-          { decodedCallData.action.label }
-        </span>
-      </div>;
+          <span className={css.summaryTitle}>
+            <img src="/assets/images/Icon/edit-sm.svg"/>&nbsp;
+            { decodedCallData.action.label }
+          </span>
+        </div>;
       default:
         return <div className={proposalSummaryClass}>
           <span className={css.summaryTitle}>

--- a/src/components/Proposal/ProposalSummary/ProposalSummaryOmenDisputeResolution.tsx
+++ b/src/components/Proposal/ProposalSummary/ProposalSummaryOmenDisputeResolution.tsx
@@ -17,6 +17,7 @@ export default class ProposalSummaryOmenDisputeResolution extends React.Componen
 
   private inputHtml = (x: any) => <span key={x.name}>{x.name} {x.type}, </span>;
   private callDataHtml = (value: any) => <div key={value}>{value}</div>;
+  private callDataValue = (value: any) => {value};
 
   public render(): RenderOutput {
     const { proposal, detailView, genericSchemeInfo, transactionModal } = this.props;
@@ -50,7 +51,7 @@ export default class ProposalSummaryOmenDisputeResolution extends React.Componen
 
           {detailView ?
             <div className={css.summaryDetails}>
-              Requested from realit.io QuestionId: <a href={"https://realitio.github.io/#!/question/"+decodedCallData.values.map(this.callDataHtml)}>{ decodedCallData.values.map(this.callDataHtml)}</a>
+              Requested from realit.io QuestionId: <a href={`https://realitio.github.io/#!/question/${decodedCallData.values.map(this.callDataValue)}` }>{ decodedCallData.values.map(this.callDataHtml)}</a>
             </div>
             : ""
           }

--- a/src/components/Proposal/ProposalSummary/ProposalSummaryOmenDisputeResolution.tsx
+++ b/src/components/Proposal/ProposalSummary/ProposalSummaryOmenDisputeResolution.tsx
@@ -47,6 +47,13 @@ export default class ProposalSummaryOmenDisputeResolution extends React.Componen
             <img src="/assets/images/Icon/edit-sm.svg"/>&nbsp;
             { decodedCallData.action.label }
           </span>
+
+          {detailView ?
+            <div className={css.summaryDetails}>
+              Requested from realit.io QuestionId: { decodedCallData.values.map(this.callDataHtml)}
+            </div>
+            : ""
+          }
         </div>;
       default:
         return <div className={proposalSummaryClass}>

--- a/src/genericSchemeRegistry/index.ts
+++ b/src/genericSchemeRegistry/index.ts
@@ -14,8 +14,8 @@ const registryLookupInfo = require("./schemes/RegistryLookup.json");
 const co2kenInfo = require("./schemes/CO2ken.json");
 const omenDisputeResolutionInfo = require("./schemes/OmenDisputeResolution.json");
 const omenTokenRegistry = require("./schemes/OmenTokenRegistry.json");
-const mixTokenRegistry = require("./schemes/mixTokenRegistry.json");
-const exchangeTokenRegistry = require("./schemes/exchangeTokenRegistry.json");
+const mixTokenRegistry = require("./schemes/MixTokenRegistry.json");
+const exchangeTokenRegistry = require("./schemes/ExchangeTokenRegistry.json");
 
 const KNOWNSCHEMES = [
   dutchXInfo,

--- a/src/genericSchemeRegistry/index.ts
+++ b/src/genericSchemeRegistry/index.ts
@@ -12,6 +12,7 @@ const ensRegistryInfo = require("./schemes/ENSRegistry.json");
 const ensPublicResolverInfo = require("./schemes/ENSPublicResolver.json");
 const registryLookupInfo = require("./schemes/RegistryLookup.json");
 const co2kenInfo = require("./schemes/CO2ken.json");
+const OmenDisputeResolutionInfo = require("./schemes/OmenDisputeResolution.json");
 
 const KNOWNSCHEMES = [
   dutchXInfo,
@@ -22,6 +23,7 @@ const KNOWNSCHEMES = [
   ensPublicResolverInfo,
   gpInfo,
   registryLookupInfo,
+  OmenDisputeResolutionInfo,
 ];
 
 const SCHEMEADDRESSES: {[network: string]: { [address: string]: any}} = {

--- a/src/genericSchemeRegistry/index.ts
+++ b/src/genericSchemeRegistry/index.ts
@@ -12,7 +12,7 @@ const ensRegistryInfo = require("./schemes/ENSRegistry.json");
 const ensPublicResolverInfo = require("./schemes/ENSPublicResolver.json");
 const registryLookupInfo = require("./schemes/RegistryLookup.json");
 const co2kenInfo = require("./schemes/CO2ken.json");
-const OmenDisputeResolutionInfo = require("./schemes/OmenDisputeResolution.json");
+const omenDisputeResolutionInfo = require("./schemes/OmenDisputeResolution.json");
 
 const KNOWNSCHEMES = [
   dutchXInfo,
@@ -23,7 +23,7 @@ const KNOWNSCHEMES = [
   ensPublicResolverInfo,
   gpInfo,
   registryLookupInfo,
-  OmenDisputeResolutionInfo,
+  omenDisputeResolutionInfo,
 ];
 
 const SCHEMEADDRESSES: {[network: string]: { [address: string]: any}} = {

--- a/src/genericSchemeRegistry/index.ts
+++ b/src/genericSchemeRegistry/index.ts
@@ -13,6 +13,9 @@ const ensPublicResolverInfo = require("./schemes/ENSPublicResolver.json");
 const registryLookupInfo = require("./schemes/RegistryLookup.json");
 const co2kenInfo = require("./schemes/CO2ken.json");
 const omenDisputeResolutionInfo = require("./schemes/OmenDisputeResolution.json");
+const omenTokenRegistry = require("./schemes/OmenTokenRegistry.json");
+const mixTokenRegistry = require("./schemes/mixTokenRegistry.json");
+const exchangeTokenRegistry = require("./schemes/exchangeTokenRegistry.json");
 
 const KNOWNSCHEMES = [
   dutchXInfo,
@@ -24,6 +27,9 @@ const KNOWNSCHEMES = [
   gpInfo,
   registryLookupInfo,
   omenDisputeResolutionInfo,
+  omenTokenRegistry,
+  mixTokenRegistry,
+  exchangeTokenRegistry
 ];
 
 const SCHEMEADDRESSES: {[network: string]: { [address: string]: any}} = {

--- a/src/genericSchemeRegistry/index.ts
+++ b/src/genericSchemeRegistry/index.ts
@@ -29,7 +29,7 @@ const KNOWNSCHEMES = [
   omenDisputeResolutionInfo,
   omenTokenRegistry,
   mixTokenRegistry,
-  exchangeTokenRegistry
+  exchangeTokenRegistry,
 ];
 
 const SCHEMEADDRESSES: {[network: string]: { [address: string]: any}} = {

--- a/src/genericSchemeRegistry/schemes/ExchangeTokenRegistry.json
+++ b/src/genericSchemeRegistry/schemes/ExchangeTokenRegistry.json
@@ -17,7 +17,7 @@
   "actions": [
     {
       "id": "addNewTokens",
-      "label": "Add new token",
+      "label": "Add new tokens",
       "description": "Add new tokens to the Omen Token Registry",
       "notes": "",
       "fields": [
@@ -44,7 +44,7 @@
     },
     {
       "id": "removeTokens",
-      "label": "Remove token",
+      "label": "Remove tokens",
       "description": "Remove tokens from the Omen Token Registry",
       "notes": "",
       "fields": [

--- a/src/genericSchemeRegistry/schemes/ExchangeTokenRegistry.json
+++ b/src/genericSchemeRegistry/schemes/ExchangeTokenRegistry.json
@@ -1,0 +1,100 @@
+{
+  "name": "Exchange Token Registry",
+  "addresses": {
+    "main": [
+      ""
+    ],
+    "rinkeby": [
+      "0xF86ab09C6a17c48B535D29fB69F95875c4856658"
+    ],
+    "kovan": [
+      "0x0fDb8A38C6AdE28df749Da43dBebb3894e751Cf0"
+    ],
+    "private": [
+      ""
+    ]
+  },
+  "actions": [
+    {
+      "id": "addNewTokens",
+      "label": "Add new tokens",
+      "description": "Add new tokens to the Omen Token Registry",
+      "notes": "",
+      "fields": [
+        {
+          "label": "Tokens",
+          "name": "_tokens",
+          "placeholder":"Address (0x0000…)"
+        }
+      ],
+      "abi": {
+        "constant": false,
+        "inputs": [
+          {
+            "name": "_tokens",
+            "type": "address[]"
+          }
+        ],
+        "name": "addNewTokens",
+        "outputs": [],
+        "payable": false,
+        "stateMutability": "nonpayable",
+        "type": "function"
+      }
+    },
+    {
+      "id": "removeTokens",
+      "label": "Remove tokens",
+      "description": "Remove tokens from the Omen Token Registry",
+      "notes": "",
+      "fields": [
+        {
+          "label": "Tokens",
+          "name": "_tokens",
+          "placeholder":"Address (0x0000…)"
+        }
+      ],
+      "abi": {
+        "constant": false,
+        "inputs": [
+          {
+            "name": "_tokens",
+            "type": "address[]"
+          }
+        ],
+        "name": "removeTokens",
+        "outputs": [],
+        "payable": false,
+        "stateMutability": "nonpayable",
+        "type": "function"
+      }
+    },
+    {
+      "id": "transferOwnership",
+      "label": "Transfer Ownership",
+      "description": "Transfer ownership  of the registry contract",
+      "notes": "",
+      "fields": [
+        {
+          "label": "New owner",
+          "name": "newOwner",
+          "placeholder": "Address (0x0000…)"
+        }
+      ],
+      "abi": {
+        "constant": false,
+        "inputs": [
+          {
+            "name": "newOwner",
+            "type": "address"
+          }
+        ],
+        "name": "transferOwnership",
+        "outputs": [],
+        "payable": false,
+        "stateMutability": "nonpayable",
+        "type": "function"
+      }
+    }
+  ]
+}

--- a/src/genericSchemeRegistry/schemes/ExchangeTokenRegistry.json
+++ b/src/genericSchemeRegistry/schemes/ExchangeTokenRegistry.json
@@ -17,7 +17,7 @@
   "actions": [
     {
       "id": "addNewTokens",
-      "label": "Add new tokens",
+      "label": "Add new token",
       "description": "Add new tokens to the Omen Token Registry",
       "notes": "",
       "fields": [
@@ -44,7 +44,7 @@
     },
     {
       "id": "removeTokens",
-      "label": "Remove tokens",
+      "label": "Remove token",
       "description": "Remove tokens from the Omen Token Registry",
       "notes": "",
       "fields": [

--- a/src/genericSchemeRegistry/schemes/MixTokenRegistry.json
+++ b/src/genericSchemeRegistry/schemes/MixTokenRegistry.json
@@ -17,7 +17,7 @@
   "actions": [
     {
       "id": "addNewTokens",
-      "label": "Add new token",
+      "label": "Add new tokens",
       "description": "Add new tokens to the Omen Token Registry",
       "notes": "",
       "fields": [
@@ -44,7 +44,7 @@
     },
     {
       "id": "removeTokens",
-      "label": "Remove token",
+      "label": "Remove tokens",
       "description": "Remove tokens from the Omen Token Registry",
       "notes": "",
       "fields": [

--- a/src/genericSchemeRegistry/schemes/MixTokenRegistry.json
+++ b/src/genericSchemeRegistry/schemes/MixTokenRegistry.json
@@ -17,7 +17,7 @@
   "actions": [
     {
       "id": "addNewTokens",
-      "label": "Add new tokens",
+      "label": "Add new token",
       "description": "Add new tokens to the Omen Token Registry",
       "notes": "",
       "fields": [
@@ -44,7 +44,7 @@
     },
     {
       "id": "removeTokens",
-      "label": "Remove tokens",
+      "label": "Remove token",
       "description": "Remove tokens from the Omen Token Registry",
       "notes": "",
       "fields": [

--- a/src/genericSchemeRegistry/schemes/MixTokenRegistry.json
+++ b/src/genericSchemeRegistry/schemes/MixTokenRegistry.json
@@ -1,0 +1,100 @@
+{
+  "name": "Mix Token Registry",
+  "addresses": {
+    "main": [
+      ""
+    ],
+    "rinkeby": [
+      "0x92d468e25bbBe47d0d266A58d0eb1E51f2276893"
+    ],
+    "kovan": [
+      "0x420459495c02e4430DC54896c50A9760fB8825a1"
+    ],
+    "private": [
+      ""
+    ]
+  },
+  "actions": [
+    {
+      "id": "addNewTokens",
+      "label": "Add new tokens",
+      "description": "Add new tokens to the Omen Token Registry",
+      "notes": "",
+      "fields": [
+        {
+          "label": "Tokens",
+          "name": "_tokens",
+          "placeholder":"Address (0x0000…)"
+        }
+      ],
+      "abi": {
+        "constant": false,
+        "inputs": [
+          {
+            "name": "_tokens",
+            "type": "address[]"
+          }
+        ],
+        "name": "addNewTokens",
+        "outputs": [],
+        "payable": false,
+        "stateMutability": "nonpayable",
+        "type": "function"
+      }
+    },
+    {
+      "id": "removeTokens",
+      "label": "Remove tokens",
+      "description": "Remove tokens from the Omen Token Registry",
+      "notes": "",
+      "fields": [
+        {
+          "label": "Tokens",
+          "name": "_tokens",
+          "placeholder":"Address (0x0000…)"
+        }
+      ],
+      "abi": {
+        "constant": false,
+        "inputs": [
+          {
+            "name": "_tokens",
+            "type": "address[]"
+          }
+        ],
+        "name": "removeTokens",
+        "outputs": [],
+        "payable": false,
+        "stateMutability": "nonpayable",
+        "type": "function"
+      }
+    },
+    {
+      "id": "transferOwnership",
+      "label": "Transfer Ownership",
+      "description": "Transfer ownership  of the registry contract",
+      "notes": "",
+      "fields": [
+        {
+          "label": "New owner",
+          "name": "newOwner",
+          "placeholder": "Address (0x0000…)"
+        }
+      ],
+      "abi": {
+        "constant": false,
+        "inputs": [
+          {
+            "name": "newOwner",
+            "type": "address"
+          }
+        ],
+        "name": "transferOwnership",
+        "outputs": [],
+        "payable": false,
+        "stateMutability": "nonpayable",
+        "type": "function"
+      }
+    }
+  ]
+}

--- a/src/genericSchemeRegistry/schemes/OmenDisputeResolution.json
+++ b/src/genericSchemeRegistry/schemes/OmenDisputeResolution.json
@@ -5,7 +5,7 @@
       ""
     ],
     "rinkeby": [
-      "0x2AD769f162807Cb0B73929fB3f0f3DaA6224d7C0"
+      "0x420459495c02e4430DC54896c50A9760fB8825a1"
     ],
     "kovan": [
       "0x1BbC8D1aa068381C5c85f65589E1c45100696bf7"

--- a/src/genericSchemeRegistry/schemes/OmenDisputeResolution.json
+++ b/src/genericSchemeRegistry/schemes/OmenDisputeResolution.json
@@ -292,7 +292,7 @@
         "inputs": [
           {
             "name": "questionId",
-            "type": "bytes"
+            "type": "bytes32"
           }
         ],
         "name": "disputeRequestNotification",

--- a/src/genericSchemeRegistry/schemes/OmenDisputeResolution.json
+++ b/src/genericSchemeRegistry/schemes/OmenDisputeResolution.json
@@ -292,7 +292,7 @@
         "inputs": [
           {
             "name": "questionId",
-            "type": "string"
+            "type": "bytes"
           }
         ],
         "name": "disputeRequestNotification",

--- a/src/genericSchemeRegistry/schemes/OmenDisputeResolution.json
+++ b/src/genericSchemeRegistry/schemes/OmenDisputeResolution.json
@@ -5,13 +5,13 @@
       ""
     ],
     "rinkeby": [
-      "0x420459495c02e4430DC54896c50A9760fB8825a1"
+      "0x216864eD7f0d38b934962E89dB76242974C9Fecd"
     ],
     "kovan": [
-      "0x1BbC8D1aa068381C5c85f65589E1c45100696bf7"
+      "0xADb50239a33Bce5a5f8ed28dD8f32BefE89c77d1"
     ],
     "private": [
-      "0xD83c3bD9DeFde5D25AD71C5d354e3c830dE3d5f8"
+      "0xA5682DF1987D214Fe4dfC3a262179eBDc205b525"
     ]
   },
   "actions": [

--- a/src/genericSchemeRegistry/schemes/OmenDisputeResolution.json
+++ b/src/genericSchemeRegistry/schemes/OmenDisputeResolution.json
@@ -5,10 +5,10 @@
       ""
     ],
     "rinkeby": [
-      "0x216864eD7f0d38b934962E89dB76242974C9Fecd"
+      "0x1f279db583c9e90Df76C42e5439F4Ceb4D5a8EeF"
     ],
     "kovan": [
-      "0xADb50239a33Bce5a5f8ed28dD8f32BefE89c77d1"
+      "0xBA72D1C70eBCBb10D4c253584ae7e976687Bee3b"
     ],
     "private": [
       "0xA5682DF1987D214Fe4dfC3a262179eBDc205b525"

--- a/src/genericSchemeRegistry/schemes/OmenDisputeResolution.json
+++ b/src/genericSchemeRegistry/schemes/OmenDisputeResolution.json
@@ -1,0 +1,296 @@
+{
+  "name": "Omen Dispute Resolution",
+  "addresses": {
+    "main": [
+      ""
+    ],
+    "rinkeby": [
+      "0x2AD769f162807Cb0B73929fB3f0f3DaA6224d7C0"
+    ],
+    "kovan": [
+      "0x1BbC8D1aa068381C5c85f65589E1c45100696bf7"
+    ],
+    "private": [
+      "0xD83c3bD9DeFde5D25AD71C5d354e3c830dE3d5f8"
+    ]
+  },
+  "actions": [
+    {
+      "id": "submitAnswerByArbitrator",
+      "label": "Propose final Answer to Question",
+      "description": "Propose the final Answer to a paused realit.io question that requested <a href=\"https://realitio.github.io/docs/html/arbitrators.html\" target=\"_blank\">Dispute Resolution.</a> The answer will be submitted as Abitrator and instantly close the question.",
+      "notes": "https://github.com/nicoelzer/Omen-Arbitrator",
+      "fields": [
+        {
+          "label": "QuestionId",
+          "name": "questionId",
+          "placeholder":"QuestionId (0x755...)"
+        },
+        {
+          "label": "Answer",
+          "name": "answer",
+          "placeholder":"Answer Hash (0x755...)"
+          
+        },
+        {
+          "label": "Answerer",
+          "name": "answerer",
+          "placeholder": "Address (0x0000…)"
+        }
+      ],
+      "abi": {
+        "constant": false,
+        "inputs": [
+          {
+            "name": "questionId",
+            "type": "bytes32"
+          },
+          {
+            "name": "answer",
+            "type": "bytes32"
+          },
+          {
+            "name": "answerer",
+            "type": "address"
+          }
+        ],
+        "name": "submitAnswerByArbitrator",
+        "outputs": [],
+        "payable": false,
+        "stateMutability": "nonpayable",
+        "type": "function"
+      }
+    },
+    {
+      "id": "setRealitio",
+      "label": "Set Contract Address",
+      "description": "Set or update the address of the realit.io contract this proposals interact with.",
+      "notes": "https://github.com/nicoelzer/Omen-Arbitrator",
+      "fields": [
+        {
+          "label": "New Contract Address",
+          "name": "_address",
+          "placeholder": "Address (0x0000…)"
+        }
+      ],
+      "abi": {
+        "constant": false,
+        "inputs": [
+          {
+            "name": "_address",
+            "type": "address"
+          }
+        ],
+        "name": "setRealitio",
+        "outputs": [],
+        "payable": false,
+        "stateMutability": "nonpayable",
+        "type": "function"
+      }
+    },
+    {
+      "id": "setMetaData",
+      "label": "Set MetaData",
+      "description": "Set or update Abitrator MetaData according the <a href=\"https://realitio.github.io/docs/html/arbitrators.html?highlight=metadata#getting-information-about-the-arbitrator\" target=\"_blank\">documentation.</a>",
+      "notes": "https://github.com/nicoelzer/Omen-Arbitrator",
+      "fields": [
+        {
+          "label": "New MetaData",
+          "name": "_metadata"
+        }
+      ],
+      "abi": {
+        "constant": false,
+        "inputs": [
+          {
+            "name": "_metadata",
+            "type": "string"
+          }
+        ],
+        "name": "setMetaData",
+        "outputs": [],
+        "payable": false,
+        "stateMutability": "nonpayable",
+        "type": "function"
+      }
+    },
+    {
+      "id": "setDisputeFee",
+      "label": "Set Dispute Fee",
+      "description": "Set or update the fee to be charged to provide Dispute Resolution as Abitrator.",
+      "notes": "https://github.com/nicoelzer/Omen-Arbitrator",
+      "fields": [
+        {
+          "label": "New DisputeFee (in WEI)",
+          "name": "_fee",
+          "placeholder":"1000000000000000000"
+        }
+      ],
+      "abi": {
+        "constant": false,
+        "inputs": [
+          {
+            "name": "_fee",
+            "type": "uint256"
+          }
+        ],
+        "name": "setDisputeFee",
+        "outputs": [],
+        "payable": false,
+        "stateMutability": "nonpayable",
+        "type": "function"
+      }
+    },
+    {
+      "id": "setFeeRecipient",
+      "label": "Set Fee Recipient",
+      "description": "Set or update the address of the recipient who will recieve charged fees.",
+      "notes": "https://github.com/nicoelzer/Omen-Arbitrator",
+      "fields": [
+        {
+          "label": "New FeeRecipient Address",
+          "name": "_recipient",
+          "placeholder": "Address (0x0000…)"
+        }
+      ],
+      "abi": {
+        "constant": false,
+        "inputs": [
+          {
+            "name": "_recipient",
+            "type": "address"
+          }
+        ],
+        "name": "setFeeRecipient",
+        "outputs": [],
+        "payable": false,
+        "stateMutability": "nonpayable",
+        "type": "function"
+      }
+    },
+    {
+      "id": "setDAOstackPlugin",
+      "label": "Set DAOstack Plugin",
+      "description": "Set or update the address of the DAOstack Plugin",
+      "notes": "https://github.com/nicoelzer/Omen-Arbitrator",
+      "fields": [
+        {
+          "label": "New address",
+          "name": "_address",
+          "placeholder": "Address (0x0000…)"
+        }
+      ],
+      "abi": {
+        "constant": false,
+        "inputs": [
+          {
+            "name": "_address",
+            "type": "address"
+          }
+        ],
+        "name": "setDAOstackPlugin",
+        "outputs": [],
+        "payable": false,
+        "stateMutability": "nonpayable",
+        "type": "function"
+      }
+    },
+    {
+      "id": "setDAOstackAvatar",
+      "label": "Set DAOstack Avatar",
+      "description": "Set or update the address of the DAOstack Avatar",
+      "notes": "https://github.com/nicoelzer/Omen-Arbitrator",
+      "fields": [
+        {
+          "label": "New address",
+          "name": "_DAOstackAvatar",
+          "placeholder": "Address (0x0000…)"
+        }
+      ],
+      "abi": {
+        "constant": false,
+        "inputs": [
+          {
+            "name": "_DAOstackAvatar",
+            "type": "address"
+          }
+        ],
+        "name": "setDAOstackAvatar",
+        "outputs": [],
+        "payable": false,
+        "stateMutability": "nonpayable",
+        "type": "function"
+      }
+    },
+    {
+      "id": "setDAOstackProposalDescriptionHash",
+      "label": "Set DAOstack Proposal Description Hash",
+      "description": "Set or update the address of the DAOstack Proposal Description Hash",
+      "notes": "https://github.com/nicoelzer/Omen-Arbitrator",
+      "fields": [
+        {
+          "label": "New Hash",
+          "name": "_descriptionHash",
+          "placeholder": "(0x0000…)"
+        }
+      ],
+      "abi": {
+        "constant": false,
+        "inputs": [
+          {
+            "name": "_descriptionHash",
+            "type": "string"
+          }
+        ],
+        "name": "setDAOstackProposalDescriptionHash",
+        "outputs": [],
+        "payable": false,
+        "stateMutability": "nonpayable",
+        "type": "function"
+      }
+    },
+    {
+      "id": "transferOwnership",
+      "label": "Transfer Ownership",
+      "description": "Transfer ownership  of the arbitrtor contract",
+      "notes": "https://github.com/nicoelzer/Omen-Arbitrator",
+      "fields": [
+        {
+          "label": "New owner",
+          "name": "newOwner",
+          "placeholder": "Address (0x0000…)"
+        }
+      ],
+      "abi": {
+        "constant": false,
+        "inputs": [
+          {
+            "name": "newOwner",
+            "type": "address"
+          }
+        ],
+        "name": "transferOwnership",
+        "outputs": [],
+        "payable": false,
+        "stateMutability": "nonpayable",
+        "type": "function"
+      }
+    },
+    {
+      "id": "disputeRequestNotification",
+      "label": "Dispute Request Notification",
+      "description": "No need for manual use. This action will be called from external contract.",
+      "notes": "https://github.com/nicoelzer/Omen-Arbitrator",
+      "fields": [],
+      "abi": {
+        "constant": false,
+        "inputs": [],
+        "name": "disputeRequestNotification",
+        "outputs": [],
+        "payable": false,
+        "stateMutability": "nonpayable",
+        "type": "function"
+      }
+    }
+  ]
+}

--- a/src/genericSchemeRegistry/schemes/OmenDisputeResolution.json
+++ b/src/genericSchemeRegistry/schemes/OmenDisputeResolution.json
@@ -281,10 +281,20 @@
       "label": "Dispute Request Notification",
       "description": "No need for manual use. This action will be called from external contract.",
       "notes": "https://github.com/nicoelzer/Omen-Arbitrator",
-      "fields": [],
+      "fields": [
+        {
+          "label": "QuestionId",
+          "name": "questionId"
+        }
+      ],
       "abi": {
         "constant": false,
-        "inputs": [],
+        "inputs": [
+          {
+            "name": "questionId",
+            "type": "string"
+          }
+        ],
         "name": "disputeRequestNotification",
         "outputs": [],
         "payable": false,

--- a/src/genericSchemeRegistry/schemes/OmenTokenRegistry.json
+++ b/src/genericSchemeRegistry/schemes/OmenTokenRegistry.json
@@ -1,0 +1,100 @@
+{
+  "name": "Omen Token Registry",
+  "addresses": {
+    "main": [
+      ""
+    ],
+    "rinkeby": [
+      "0x1BB96C24CbA4522810d9129db2e5d24546241F24"
+    ],
+    "kovan": [
+      "0xA2753ee3B7424b53a6578AF86068fB64F6531dFf"
+    ],
+    "private": [
+      ""
+    ]
+  },
+  "actions": [
+    {
+      "id": "addNewTokens",
+      "label": "Add new tokens",
+      "description": "Add new tokens to the Omen Token Registry",
+      "notes": "",
+      "fields": [
+        {
+          "label": "Tokens",
+          "name": "_tokens",
+          "placeholder":"Address (0x0000…)"
+        }
+      ],
+      "abi": {
+        "constant": false,
+        "inputs": [
+          {
+            "name": "_tokens",
+            "type": "address[]"
+          }
+        ],
+        "name": "addNewTokens",
+        "outputs": [],
+        "payable": false,
+        "stateMutability": "nonpayable",
+        "type": "function"
+      }
+    },
+    {
+      "id": "removeTokens",
+      "label": "Remove tokens",
+      "description": "Remove tokens from the Omen Token Registry",
+      "notes": "",
+      "fields": [
+        {
+          "label": "Tokens",
+          "name": "_tokens",
+          "placeholder":"Address (0x0000…)"
+        }
+      ],
+      "abi": {
+        "constant": false,
+        "inputs": [
+          {
+            "name": "_tokens",
+            "type": "address[]"
+          }
+        ],
+        "name": "removeTokens",
+        "outputs": [],
+        "payable": false,
+        "stateMutability": "nonpayable",
+        "type": "function"
+      }
+    },
+    {
+      "id": "transferOwnership",
+      "label": "Transfer Ownership",
+      "description": "Transfer ownership  of the registry contract",
+      "notes": "",
+      "fields": [
+        {
+          "label": "New owner",
+          "name": "newOwner",
+          "placeholder": "Address (0x0000…)"
+        }
+      ],
+      "abi": {
+        "constant": false,
+        "inputs": [
+          {
+            "name": "newOwner",
+            "type": "address"
+          }
+        ],
+        "name": "transferOwnership",
+        "outputs": [],
+        "payable": false,
+        "stateMutability": "nonpayable",
+        "type": "function"
+      }
+    }
+  ]
+}

--- a/src/genericSchemeRegistry/schemes/OmenTokenRegistry.json
+++ b/src/genericSchemeRegistry/schemes/OmenTokenRegistry.json
@@ -17,7 +17,7 @@
   "actions": [
     {
       "id": "addNewTokens",
-      "label": "Add new token",
+      "label": "Add new tokens",
       "description": "Add new tokens to the Omen Token Registry",
       "notes": "",
       "fields": [
@@ -44,7 +44,7 @@
     },
     {
       "id": "removeTokens",
-      "label": "Remove token",
+      "label": "Remove tokens",
       "description": "Remove tokens from the Omen Token Registry",
       "notes": "",
       "fields": [

--- a/src/genericSchemeRegistry/schemes/OmenTokenRegistry.json
+++ b/src/genericSchemeRegistry/schemes/OmenTokenRegistry.json
@@ -17,7 +17,7 @@
   "actions": [
     {
       "id": "addNewTokens",
-      "label": "Add new tokens",
+      "label": "Add new token",
       "description": "Add new tokens to the Omen Token Registry",
       "notes": "",
       "fields": [
@@ -44,7 +44,7 @@
     },
     {
       "id": "removeTokens",
-      "label": "Remove tokens",
+      "label": "Remove token",
       "description": "Remove tokens from the Omen Token Registry",
       "notes": "",
       "fields": [


### PR DESCRIPTION
This commit adds a GenericScheme to integrate the DxDAO with realit.io as arbitrator to resolve disputes. More information can be found:

- https://daotalk.org/t/omen-mvp-overview/1229 (Section Arbitration)
- https://realitio.github.io/docs/html/arbitrators.html

This PR provides the GenericScheme for Kovan & Rinkeby for testing purposes. Mainnet will be added later.