### PR TITLE
Import torus using require

### DIFF
--- a/src/settings.ts
+++ b/src/settings.ts
@@ -4,7 +4,7 @@ export const ETHDENVER_OPTIMIZATION = true;
 export const USE_CONTRACTINFOS_CACHE = false;
 import BurnerConnectProvider from "@burner-wallet/burner-connect-provider";
 import WalletConnectProvider from "@walletconnect/web3-provider";
-import Torus from "@toruslabs/torus-embed";
+const Torus = require("@toruslabs/torus-embed");
 
 const Portis = require("@portis/web3");
 const Fortmatic = require("fortmatic");


### PR DESCRIPTION
our build process was changed slightly

this import still works if you enable esModuleInterop: true in your tsconfig but there are other issues if you do that in the alchemy repo. 

Instead, if you import it via require, it just works.

Ran this via npm run start-prod and was able to see Torus in the Web3Modal modal, and also login successfully. 