### PR TITLE
Don't show weird confirmation popups when using the "Pending" notification type

### DIFF
--- a/src/components/Notification/Notification.tsx
+++ b/src/components/Notification/Notification.tsx
@@ -29,14 +29,7 @@ export default class Notification extends React.Component<IProps, null> {
   }
 
   private handleClose = (): void => {
-    const { dismiss, status } = this.props;
-    if (status === NotificationViewStatus.Pending) {
-      if (confirm("Often transactions get approved after 24h, closing this will prevent you from following the status of the tx, are you sure you would like to close this?")) {
-        dismiss();
-      }
-    } else {
-      dismiss();
-    }
+    this.props.dismiss();
   }
 
   private copyToClipboard = (message: string) => (): void => {


### PR DESCRIPTION
Fixes a weird "bug" in the Biconomy PR