### PR TITLE
refactor and fix the layout of New Proposal button

### DIFF
--- a/src/components/Scheme/Scheme.scss
+++ b/src/components/Scheme/Scheme.scss
@@ -8,7 +8,7 @@
   color: #689ad6;
   padding: 0;
   margin: 0;
-  padding-bottom: 15px;
+  margin-bottom: 30px;
   background-color: #e5ebf2;
   padding-top: 10px;
 }
@@ -17,42 +17,76 @@
   width: 100%;
   background-color: rgba(229, 235, 242, 1);
   border-bottom: 1px solid rgba(212, 220, 228, 1);
-  padding-top: 15px;
-  position: relative;
-  margin-bottom: 20px;
+  margin-bottom: 15px;
 
-  a {
-    color: rgba(0, 29, 53, 1);
-    display: inline-block;
-    font-size: 16px;
-    transition: all 0.25s ease;
-  }
+  .row {
+    display: flex;
 
-  a:visited {
-    color: rgba(0, 29, 53, 1);
-  }
+    .tabs {
+      flex-grow: 2;
+      white-space: nowrap;
 
-  .proposals,
-  .info,
-  .crx,
-  .openbounty {
-    border-bottom: 2px solid rgba(34, 128, 254, 0);
-    /* TODO: for .crx this left/right padding may not be appropriate for all CrX rewarder contracts. */
-    padding: 10px 24px;
-  }
+      a {
+        color: rgba(0, 29, 53, 1);
+        display: inline-block;
+        font-size: 16px;
+        transition: all 0.25s ease;
+      }
 
-  .proposals.active,
-  .info.active,
-  .crx.active,
-  .openbounty.active {
-    border-bottom: 2px solid rgba(34, 128, 254, 1);
-  }
+      a:visited {
+        color: rgba(0, 29, 53, 1);
+      }
 
-  .proposals:hover,
-  .info:hover,
-  .crx:hover,
-  .openbounty:hover {
-    border-bottom: 2px solid rgba(34, 128, 254, 0.5);
+      .proposals,
+      .info,
+      .crx,
+      .openbounty {
+        border-bottom: 2px solid rgba(34, 128, 254, 0);
+        /* TODO: for .crx this left/right padding may not be appropriate for all CrX rewarder contracts. */
+        padding: 10px 24px 10px 24px;
+      }
+
+      .proposals.active,
+      .info.active,
+      .crx.active,
+      .openbounty.active {
+        border-bottom: 2px solid rgba(34, 128, 254, 1);
+      }
+
+      .proposals:hover,
+      .info:hover,
+      .crx:hover,
+      .openbounty:hover {
+        border-bottom: 2px solid rgba(34, 128, 254, 0.5);
+      }
+    }
+
+    .editPlugin,
+    .createProposal {
+      align-self: center;
+
+      a {
+        padding: 8px 15px;
+        color: $white;
+        background-color: rgba(3, 118, 255, 1);
+        border-radius: 15px;
+        font-size: 13px;
+        white-space: nowrap;
+        display: inline-block;
+
+        &:hover {
+          background-color: $accent-1;
+          color: $white;
+        }
+
+        .disabled,
+        .disabled:hover {
+          background-color: rgba(200, 200, 200, 0.5);
+          border: 1px solid rgba(200, 200, 200, 1);
+          cursor: not-allowed;
+        }
+      }
+    }
   }
 }
 
@@ -159,8 +193,18 @@
   }
 
   .schemeMenu {
-    a {
-      font-size: 12px;
+    text-align: center;
+    .row {
+      display: inline-block;
+      margin-bottom: 8px;
+
+      .tabs {
+        display: block;
+        margin-bottom: 1rem;
+        a {
+          font-size: 12px;
+        }
+      }
     }
   }
 }

--- a/src/components/Scheme/SchemeContainer.tsx
+++ b/src/components/Scheme/SchemeContainer.tsx
@@ -1,7 +1,7 @@
 import { History } from "history";
 import { first, filter, toArray, mergeMap } from "rxjs/operators";
 import { Address, CompetitionScheme, IProposalStage, IDAOState, ISchemeState, IProposalState, IProposalOutcome, Scheme } from "@daostack/arc.js";
-import { getArc } from "arc";
+import { getArc, enableWalletProvider } from "arc";
 import classNames from "classnames";
 import Loading from "components/Shared/Loading";
 import withSubscription, { ISubscriptionProps } from "components/Shared/withSubscription";
@@ -69,7 +69,12 @@ class SchemeContainer extends React.Component<IProps, IState> {
   }
 
   private schemeInfoPageHtml = (props: any) => <SchemeInfoPage {...props} daoState={this.props.daoState} scheme={this.props.data[0]} schemeManager={this.props.data[1]} />;
-  private schemeProposalsPageHtml = (isActive: boolean, crxRewarderProps: ICrxRewarderProps) => (props: any) => <SchemeProposalsPage {...props} isActive={isActive} daoState={this.props.daoState} currentAccountAddress={this.props.currentAccountAddress} scheme={this.props.data[0]} crxRewarderProps={crxRewarderProps} />;
+  private schemeProposalsPageHtml = (isActive: boolean, crxRewarderProps: ICrxRewarderProps) => (props: any) =>
+    <SchemeProposalsPage {...props}
+      isActive={isActive}
+      daoState={this.props.daoState}
+      currentAccountAddress={this.props.currentAccountAddress}
+      scheme={this.props.data[0]}crxRewarderProps={crxRewarderProps} />;
   private contributionsRewardExtTabHtml = () => (props: any) =>
   {
     if (!this.state.crxListComponent) {
@@ -94,11 +99,28 @@ class SchemeContainer extends React.Component<IProps, IState> {
     this.setState(newState);
   }
 
+  private handleNewProposal = async (e: any): Promise<void> => {
+    if (!await enableWalletProvider({ showNotification: this.props.showNotification })) { return; }
+
+    this.props.history.push(`/dao/${this.props.daoState.address}/scheme/${this.props.schemeId}/proposals/create/`);
+
+    e.preventDefault();
+  };
+
+  private handleEditPlugin = async (e: any) => {
+    if (!await enableWalletProvider({ showNotification: this.props.showNotification })) { return; }
+
+    this.props.history.push(`/dao/${this.props.daoState.id}/scheme/${this.props.schemeId}/proposals/create/?currentTab=editScheme`);
+    e.preventDefault();
+  }
+
+
   public render(): RenderOutput {
     const { schemeId, daoState } = this.props;
     const daoAvatarAddress = daoState.address;
     const schemeState = this.props.data[0];
     const approvedProposals = this.props.data[2];
+    const inInfoTab = this.props.location.pathname.match(/info\/*$/i);
 
     if (schemeState.name === "ReputationFromToken") {
       return <ReputationFromToken {...this.props} daoAvatarAddress={daoAvatarAddress} schemeState={schemeState} />;
@@ -109,11 +131,11 @@ class SchemeContainer extends React.Component<IProps, IState> {
 
     const proposalsTabClass = classNames({
       [css.proposals]: true,
-      [css.active]: isProposalScheme && !this.props.location.pathname.includes("info") && !this.props.location.pathname.includes("crx") && !this.props.location.pathname.includes("open"),
+      [css.active]: isProposalScheme && !inInfoTab && !this.props.location.pathname.includes("crx") && !this.props.location.pathname.includes("open"),
     });
     const infoTabClass = classNames({
       [css.info]: true,
-      [css.active]: !isProposalScheme || this.props.location.pathname.includes("info"),
+      [css.active]: !isProposalScheme || inInfoTab,
     });
     const openBountiesTabClass = classNames({
       [css.openbounty]: true,
@@ -125,7 +147,6 @@ class SchemeContainer extends React.Component<IProps, IState> {
       [css.active]: this.props.location.pathname.includes("crx"),
     });
     const schemeFriendlyName = schemeName(schemeState, schemeState.address);
-
 
     return (
       <div className={css.schemeContainer}>
@@ -143,25 +164,58 @@ class SchemeContainer extends React.Component<IProps, IState> {
           </h2>
 
           <div className={css.schemeMenu}>
-            {isProposalScheme
-              ? <Link className={proposalsTabClass} to={`/dao/${daoAvatarAddress}/scheme/${schemeId}/proposals/`}>Proposals</Link>
-              : ""}
 
-            { // if Bounties Scheme, create new tab
-              (schemeName(schemeState, schemeState.address) === "Standard Bounties") &&
-              <Link className={openBountiesTabClass} to={`/dao/${daoAvatarAddress}/scheme/${schemeId}/openbounties/`}>Open Bounties</Link>
-            }
+            <div className={css.row}>
+              <div className={css.tabs}>
+                {isProposalScheme
+                  ? <Link className={proposalsTabClass} to={`/dao/${daoAvatarAddress}/scheme/${schemeId}/proposals/`}>Proposals</Link>
+                  : ""}
 
-            <TrainingTooltip placement="top" overlay={"Learn about the protocol parameters for this scheme"}>
-              <Link className={infoTabClass} to={`/dao/${daoAvatarAddress}/scheme/${schemeId}/info/`}>Information</Link>
-            </TrainingTooltip>
-            {
-              this.state.crxRewarderProps ?
-                <TrainingTooltip placement="top" overlay={this.state.crxRewarderProps.shortDescription}>
-                  <Link className={crxTabClass} to={`/dao/${daoAvatarAddress}/scheme/${schemeId}/crx/`}>{this.state.crxRewarderProps.friendlyName} ({approvedProposals.length})</Link>
+                { // if Bounties Scheme, create new tab
+                  (schemeName(schemeState, schemeState.address) === "Standard Bounties") &&
+                    <Link className={openBountiesTabClass} to={`/dao/${daoAvatarAddress}/scheme/${schemeId}/openbounties/`}>Open Bounties</Link>
+                }
+
+                <TrainingTooltip placement="top" overlay={"Learn about the protocol parameters for this scheme"}>
+                  <Link className={infoTabClass} to={`/dao/${daoAvatarAddress}/scheme/${schemeId}/info/`}>Information</Link>
                 </TrainingTooltip>
-                : ""
-            }
+                {
+                  this.state.crxRewarderProps ?
+                    <TrainingTooltip placement="top" overlay={this.state.crxRewarderProps.shortDescription}>
+                      <Link className={crxTabClass} to={`/dao/${daoAvatarAddress}/scheme/${schemeId}/crx/`}>{this.state.crxRewarderProps.friendlyName} ({approvedProposals.length})</Link>
+                    </TrainingTooltip>
+                    : ""
+                }
+              </div>
+
+              {inInfoTab ?
+                <div className={css.editPlugin}>
+                  <TrainingTooltip placement="topRight" overlay={"A small amount of ETH is necessary to submit a proposal in order to pay gas costs"}>
+                    <a
+                      data-test-id="createProposal"
+                      href="#!"
+                      onClick={this.handleEditPlugin}
+                    >
+                    Edit Plugin
+                    </a>
+                  </TrainingTooltip>
+                </div>
+                :
+                <div className={css.createProposal}>
+                  <TrainingTooltip placement="topRight" overlay={"A small amount of ETH is necessary to submit a proposal in order to pay gas costs"}>
+                    <a className={
+                      classNames({
+                        [css.disabled]: !isActive,
+                      })}
+                    data-test-id="createProposal"
+                    href="#!"
+                    onClick={isActive ? this.handleNewProposal : null}
+                    >
+                  + New Proposal</a>
+                  </TrainingTooltip>
+                </div>
+              }
+            </div>
           </div>
         </Sticky>
 

--- a/src/components/Scheme/SchemeInfo.scss
+++ b/src/components/Scheme/SchemeInfo.scss
@@ -92,35 +92,6 @@
   cursor: pointer;
 }
 
-.editPlugin {
-  z-index: 1000000;
-  position: fixed;
-  right: 0;
-  top: 155px;
-  text-align: right;
-
-  a {
-    padding: 8px 15px;
-    color: $white;
-    background-color: rgba(3, 118, 255, 1);
-    border-radius: 15px;
-    font-size: 13px;
-    white-space: nowrap;
-
-    &:hover {
-      background-color: $accent-1;
-      color: $white;
-    }
-
-    &.disabled,
-    &.disabled:hover {
-      background-color: rgba(200, 200, 200, 0.5);
-      border: 1px solid rgba(200, 200, 200, 1);
-      cursor: not-allowed;
-    }
-  }
-}
-
 @media only screen and (max-width: 425px) {
   .ellipsis {
     position: relative;

--- a/src/components/Scheme/SchemeInfoPage.tsx
+++ b/src/components/Scheme/SchemeInfoPage.tsx
@@ -1,6 +1,5 @@
 /* tslint:disable:max-classes-per-file */
 
-import { enableWalletProvider } from "arc";
 import { History } from "history";
 import * as React from "react";
 import { BreadcrumbsItem } from "react-breadcrumbs-dynamic";
@@ -11,7 +10,6 @@ import * as moment from "moment";
 import { NotificationStatus, showNotification } from "reducers/notifications";
 import { connect } from "react-redux";
 import Tooltip from "rc-tooltip";
-import TrainingTooltip from "components/Shared/TrainingTooltip";
 import * as css from "./SchemeInfo.scss";
 
 interface IDispatchProps {
@@ -37,13 +35,6 @@ class SchemeInfo extends React.Component<IProps, null> {
     copyToClipboard(str);
     this.props.showNotification(NotificationStatus.Success, "Copied to clipboard!");
   };
-
-  private handleEditPlugin = async (e: any) => {
-    if (!await enableWalletProvider({ showNotification: this.props.showNotification })) { return; }
-
-    this.props.history.push(`/dao/${this.props.daoState.id}/scheme/${this.props.schemeManager.id}/proposals/create/?currentTab=editScheme`);
-    e.preventDefault();
-  }
 
   public render(): RenderOutput {
     const { daoState, scheme } = this.props;
@@ -131,18 +122,6 @@ class SchemeInfo extends React.Component<IProps, null> {
     );
     return <div>
       <BreadcrumbsItem to={`/dao/${daoAvatarAddress}/scheme/${scheme.id}/info`}>Info</BreadcrumbsItem>
-
-      <div className={css.editPlugin}>
-        <TrainingTooltip placement="topRight" overlay={"A small amount of ETH is necessary to submit a proposal in order to pay gas costs"}>
-          <a
-            data-test-id="createProposal"
-            href="#!"
-            onClick={this.handleEditPlugin}
-          >
-            Edit Plugin
-          </a>
-        </TrainingTooltip>
-      </div>
 
       <div className={css.schemeInfoContainer}>
         <h3>{schemeName(scheme, scheme.address)}</h3>

--- a/src/components/Scheme/SchemeProposals.scss
+++ b/src/components/Scheme/SchemeProposals.scss
@@ -120,32 +120,3 @@
     margin-top: 8px;
   }
 }
-
-.createProposal {
-  z-index: 1000000;
-  position: fixed;
-  right: 0;
-  top: 155px;
-  text-align: right;
-
-  a {
-    padding: 8px 15px;
-    color: $white;
-    background-color: rgba(3, 118, 255, 1);
-    border-radius: 15px;
-    font-size: 13px;
-    white-space: nowrap;
-
-    &:hover {
-      background-color: $accent-1;
-      color: $white;
-    }
-
-    &.disabled,
-    &.disabled:hover {
-      background-color: rgba(200, 200, 200, 0.5);
-      border: 1px solid rgba(200, 200, 200, 1);
-      cursor: not-allowed;
-    }
-  }
-}

--- a/src/components/Scheme/SchemeProposalsPage.tsx
+++ b/src/components/Scheme/SchemeProposalsPage.tsx
@@ -1,6 +1,6 @@
 import { History } from "history";
 import { Address, IDAOState, IProposalStage, ISchemeState, Proposal, Vote, Reward, Scheme, Stake } from "@daostack/arc.js";
-import { enableWalletProvider, getArc } from "arc";
+import { getArc } from "arc";
 import Loading from "components/Shared/Loading";
 import withSubscription, { ISubscriptionProps } from "components/Shared/withSubscription";
 import gql from "graphql-tag";
@@ -45,6 +45,7 @@ interface IExternalProps {
   scheme: ISchemeState;
   daoState: IDAOState;
   crxRewarderProps: any;
+  handleNewProposal: (e: any) => void;
 }
 
 interface IDispatchProps {
@@ -69,17 +70,6 @@ class SchemeProposalsPage extends React.Component<IProps, null> {
       "Scheme Name": this.props.scheme.name,
     });
   }
-
-  private async handleNewProposal(daoAvatarAddress: Address, schemeId: any): Promise<void> {
-    if (!await enableWalletProvider({ showNotification: this.props.showNotification })) { return; }
-
-    this.props.history.push(`/dao/${daoAvatarAddress}/scheme/${schemeId}/proposals/create/`);
-  }
-
-  private _handleNewProposal = (e: any): void => {
-    this.handleNewProposal(this.props.daoState.address, this.props.scheme.id);
-    e.preventDefault();
-  };
 
   public render(): RenderOutput {
     const { data } = this.props;
@@ -128,21 +118,6 @@ class SchemeProposalsPage extends React.Component<IProps, null> {
       <div>
         <BreadcrumbsItem to={`/dao/${daoState.address}/scheme/${scheme.id}`}>{schemeFriendlyName}</BreadcrumbsItem>
 
-        <div className={css.createProposal}>
-          <TrainingTooltip placement="topRight" overlay={"A small amount of ETH is necessary to submit a proposal in order to pay gas costs"}>
-            <a className={
-              classNames({
-                [css.createProposal]: true,
-                [css.disabled]: !isActive,
-              })}
-            data-test-id="createProposal"
-            href="#!"
-            onClick={isActive ? this._handleNewProposal : null}
-            >
-          + New { `${this.props.crxRewarderProps ? this.props.crxRewarderProps.contractName : schemeFriendlyName } `}Proposal</a>
-          </TrainingTooltip>
-        </div>
-
         { proposalsQueued.length === 0 && proposalsPreBoosted.length === 0 && proposalsBoosted.length === 0
           ?
           <div className={css.noDecisions}>
@@ -160,7 +135,7 @@ class SchemeProposalsPage extends React.Component<IProps, null> {
                 [css.disabled]: !isActive,
               })}
               href="#!"
-              onClick={isActive ? this._handleNewProposal : null}
+              onClick={isActive ? this.props.handleNewProposal : null}
               data-test-id="createProposal"
               >+ New Proposal</a>
             </div>


### PR DESCRIPTION
Resolves: https://github.com/daostack/alchemy/issues/1674

- This moves the code for the New Proposal and Edit Plugin buttons into the components where they belong, instead of hacking them from the wrong components.
- The appearance of the two buttons is now consistent with the appearance of a similar button:  Edit Plugin on the Proposal Plugins page
- I removed the name of the plugin from the "New Proposal" button because the button is harder to layout when it becomes very wide, and the name is redundant.
- responsive behavior is better than it was, I think, but still not great

There are more notes in the ticket this fixes.

Potentially affected parts, to test:

- the SchemeContainer page for any scheme, (url: /dao/:daoAvatarAddress/scheme/:schemeId) for any scheme, not neglecting special cases of ReputationFromToken, Competition and Bounty
  - Proposals tab (add Proposal button)
    - with no proposals
    - with proposals
  - the Information tab (Edit Plugin button)
    - it is possible that ReputationFromToken, Competition and Bounty don't have an Edit Plugin button.  If that is an issue, then please create a separate ticket.