### PR TITLE
New Member

### DIFF
--- a/src/genericSchemeRegistry/index.ts
+++ b/src/genericSchemeRegistry/index.ts
@@ -13,6 +13,7 @@ const ensPublicResolverInfo = require("./schemes/ENSPublicResolver.json");
 const registryLookupInfo = require("./schemes/RegistryLookup.json");
 const co2kenInfo = require("./schemes/CO2ken.json");
 const dXTokenRegistry = require("./schemes/dXTokenRegistry.json");
+const NewMember = require("./schemes/NewMember.json");
 
 const KNOWNSCHEMES = [
   dutchXInfo,
@@ -24,6 +25,7 @@ const KNOWNSCHEMES = [
   gpInfo,
   registryLookupInfo,
   dXTokenRegistry,
+  NewMember,
 ];
 
 const SCHEMEADDRESSES: {[network: string]: { [address: string]: any}} = {

--- a/src/genericSchemeRegistry/schemes/NewMember.json
+++ b/src/genericSchemeRegistry/schemes/NewMember.json
@@ -1,0 +1,49 @@
+{
+  "name": "NewMember",
+  "addresses": {
+    "xdai": [
+      "0xb24f5c82462634421b005dc7352bcfad04bc8d3a"
+    ]
+  },
+  "actions": [
+    {
+      "id": "NewMember"
+      "label": "This is a new member proposal to the builder collective",
+      "description": "Introduce yourself to the members of the cooperative and if approved by the members, recieve reputation (Voting power). Please fill out your name, Discord id (to find it write \@yourname in the discord chat), your skills, and something that you are excited about. for the full guide on how to participate please go <a target=\"_blank\" href=\"https://builderco.org/onboarding\">here</a>",
+      "notes": "builderco.org/proposal",
+      "fields": [
+        {
+          "label": "Your Address",
+          "name": "_user",
+          "placeholder": "Address (0x0000…)"
+        },
+         {
+          "label": "Reputation Amount",
+          "name": "_amount",
+         },
+      ],
+
+      "abi": {
+        "constant": false,
+        "inputs": [
+        {
+          "internalType": "address",
+          "name": "_user",
+          "type": "uint256"
+        },
+        {
+          "internalType": "uint256",
+          "name": "_amount",
+          "type": "uint256"
+        }
+      ],
+  }
+      "name": "mint",
+      "outputs": [
+        {
+          "internalType": "bool",
+          "name": "",
+          "type": "bool"
+        }
+      ],
+  }


### PR DESCRIPTION
Add NewMember Generic scheme to onboard new members, strictly to get rep

I Followed the readme with some help from Oren.

User story: 
Scheme for introductions and onboarding to the DAO, the only action you can do is create an "onboarding proposal" that can mint reputation.
User:
- Writes a description
- Inserts Ethereum Address (autofill / own address)
- Set rep reward (Predefined at a later stage)

I may have some syntax errors, I hope not.