### PR TITLE
fix ensPublicResolver setAddr encoding

### DIFF
--- a/src/genericSchemeRegistry/schemes/ENSPublicResolver.json
+++ b/src/genericSchemeRegistry/schemes/ENSPublicResolver.json
@@ -39,7 +39,7 @@
           },
           {
             "name": "address",
-            "type": "string"
+            "type": "address"
           }
         ],
         "name": "setAddr",


### PR DESCRIPTION
input param type should be "address" not "string".

- When using ensPublicResolver generic scheme , calling setAddr produce wrong encoded abi . due to bug in the abi set for this function. 
- This cause the executed generic call proposal to revert at the ENS side. The proposal will look in alchemy as if it passed though.
