### PR TITLE
fix redemption numbers in menu

### DIFF
--- a/src/components/Proposal/RedemptionsString.scss
+++ b/src/components/Proposal/RedemptionsString.scss
@@ -1,0 +1,11 @@
+.container {
+  display: inline-block;
+  color: rgba(49, 120, 202, 1);
+
+  .reward {
+    display: inline-block;
+    .separator {
+      font-weight: 600;
+    }
+  }
+}


### PR DESCRIPTION
Resolves: https://github.com/daostack/alchemy/issues/1588

There were significant issues here.  Both GEN and reputation numbers were going to be off in multiple scenarios.

I was compelled to clean up a little display code in the process, as it was written in a way that was difficult to evaluate for correctness.

The part of the UI that is fixed is here:

![image](https://user-images.githubusercontent.com/1821666/82824709-cd3f5c80-9e77-11ea-9411-2a51bc82e4d7.png)
