### PR TITLE
Fix UI issue in staking modal

### DIFF
--- a/src/components/Shared/PreTransactionModal.scss
+++ b/src/components/Shared/PreTransactionModal.scss
@@ -4,7 +4,7 @@
 
 .genLabel.genSymbol {
   top: 3px;
-  left: 143px;
+  left: 110px;
   opacity: .5;
   position: absolute;
 }


### PR DESCRIPTION
**Note**
- I fixed the issue only by changing styling.
- Tested on Chrome, Firefox and Brave browsers.
- If this issue will pop up again I'll make a more robust fix with the template itself and not only with CSS.
- I also checked the error message itself and not only the "GEN" text and it's fine, although I saw in previous discussions that others had problems with this.