### PR TITLE
Added validation to Custom Contract To Call field

### DIFF
--- a/src/components/Proposal/Create/PluginForms/PluginInitializeFields.tsx
+++ b/src/components/Proposal/Create/PluginForms/PluginInitializeFields.tsx
@@ -99,7 +99,7 @@ const GenericSchemeFields: React.FC<IProps> = ({ values }) => {
           ))}
         </Field>
         {isCustom &&
-          fieldView("GenericScheme", "Custom Contract To Call", "contractToCall")}
+          fieldView("GenericScheme", "Custom Contract To Call", "contractToCall", validators.address)}
         <a href={linkToEtherScan(contractToCall)} target="_blank" rel="noopener noreferrer">{contractToCall}</a>
       </div>
       {GenesisProtocolFields("GenericScheme.votingParams")}


### PR DESCRIPTION
Added address validation to 'Custom Contract To Call' field when creating a new proposal with 'GenricScheme' plugin.