### PR TITLE
handle wide GenericScheme calldata

### DIFF
--- a/src/components/Proposal/ProposalSummary/ProposalSummary.scss
+++ b/src/components/Proposal/ProposalSummary/ProposalSummary.scss
@@ -111,6 +111,10 @@
     padding: 20px;
     margin: 0;
 
+    a {
+      color: #0071ff;
+    }
+
     th {
       color: rgba(78, 97, 118, 1);
       font-weight: normal;

--- a/src/components/Proposal/ProposalSummary/ProposalSummaryKnownGenericScheme.tsx
+++ b/src/components/Proposal/ProposalSummary/ProposalSummaryKnownGenericScheme.tsx
@@ -32,10 +32,7 @@ export default class ProposalSummary extends React.Component<IProps> {
       return <div
         className={isArrayItem ? css.arrayItem : ""}
         key={value}
-      >{value}<CopyToClipboard
-          value={value}
-
-        />{isArrayItem ? "," : ""}
+      >{value}<CopyToClipboard value={value}/>{isArrayItem ? "," : ""}
       </div>;
 
     } else {
@@ -74,8 +71,8 @@ export default class ProposalSummary extends React.Component<IProps> {
           </span>
           {detailView ?
             <div className={css.summaryDetails}>
-              to contract at <a href={linkToEtherScan(proposal.genericScheme.contractToCall)}>{proposal.genericScheme.contractToCall.substr(0, 8)}...</a>
-              with callData: <pre>{proposal.genericScheme.callData}</pre>
+              To contract at: <pre><a href={linkToEtherScan(proposal.genericScheme.contractToCall)} target="_blank" rel="noopener noreferrer">{proposal.genericScheme.contractToCall}</a></pre>
+              With callData: <pre>{truncateWithEllipses(proposal.genericScheme.callData, 42)}<CopyToClipboard value={proposal.genericScheme.callData} /></pre>
             </div>
             : ""
           }

--- a/src/components/Proposal/ProposalSummary/ProposalSummaryKnownGenericScheme.tsx
+++ b/src/components/Proposal/ProposalSummary/ProposalSummaryKnownGenericScheme.tsx
@@ -72,7 +72,7 @@ export default class ProposalSummary extends React.Component<IProps> {
           {detailView ?
             <div className={css.summaryDetails}>
               To contract at: <pre><a href={linkToEtherScan(proposal.genericScheme.contractToCall)} target="_blank" rel="noopener noreferrer">{proposal.genericScheme.contractToCall}</a></pre>
-              With callData: <pre>{truncateWithEllipses(proposal.genericScheme.callData, 42)}<CopyToClipboard value={proposal.genericScheme.callData} /></pre>
+              with callData: <pre>{truncateWithEllipses(proposal.genericScheme.callData, 42)}<CopyToClipboard value={proposal.genericScheme.callData} /></pre>
             </div>
             : ""
           }

--- a/src/components/Proposal/ProposalSummary/ProposalSummaryUnknownGenericScheme.tsx
+++ b/src/components/Proposal/ProposalSummary/ProposalSummaryUnknownGenericScheme.tsx
@@ -43,9 +43,9 @@ export default class ProposalSummary extends React.Component<IProps, IState> {
         </span>
         {detailView ?
           <div className={css.summaryDetails}>
-            on contract at:
-            <pre><a href={linkToEtherScan(proposal.genericScheme.contractToCall)}>{proposal.genericScheme.contractToCall}</a></pre>
-            sending to contract:
+            To contract at:
+            <pre><a href={linkToEtherScan(proposal.genericScheme.contractToCall)} target="_blank" rel="noopener noreferrer">{proposal.genericScheme.contractToCall}</a></pre>
+            Sending to contract:
             <pre className={sendsETH ? css.warning : ""}>{formatTokens(proposal.genericScheme.value)} ETH</pre>
           </div>
           : ""

--- a/src/components/Proposal/ProposalSummary/ProposalSummaryUnknownGenericScheme.tsx
+++ b/src/components/Proposal/ProposalSummary/ProposalSummaryUnknownGenericScheme.tsx
@@ -45,7 +45,7 @@ export default class ProposalSummary extends React.Component<IProps, IState> {
           <div className={css.summaryDetails}>
             To contract at:
             <pre><a href={linkToEtherScan(proposal.genericScheme.contractToCall)} target="_blank" rel="noopener noreferrer">{proposal.genericScheme.contractToCall}</a></pre>
-            Sending to contract:
+            sending to contract:
             <pre className={sendsETH ? css.warning : ""}>{formatTokens(proposal.genericScheme.value)} ETH</pre>
           </div>
           : ""


### PR DESCRIPTION
Resolves: https://github.com/daostack/alchemy/issues/1856

- truncates the callData value and adds CopyToClipboard button
- makes contract address fully visible (consistent with unknown schemes)
- makes a few needed cosmetic improvements consistent with other proposal details pages
- makes the etherscan link open safely, and in a new tab