### PR TITLE
prepare for MetaMask ceasing to inject web3

### DIFF
--- a/src/arc.ts
+++ b/src/arc.ts
@@ -316,8 +316,9 @@ async function enableWeb3Provider(): Promise<void> {
          * doesn't behave well when there is no available extension.  The fallback is
          * apparently "for injected providers that haven't been added to the library or
          * that don't support the normal specification. Opera is an example of it."
+         * [UPDATE:]  Opera has been added to Web3Modal.
          */
-        { disableInjectedProvider: !((window as any).web3 || (window as any).ethereum) },
+        { disableInjectedProvider: !(window as any).ethereum },
         getArcSettings().web3ConnectProviderOptions) as any,
     });
 
@@ -477,10 +478,12 @@ export async function enableWalletProvider(options: IEnableWalletProviderParams)
       return true;
     }
 
-    // If not MetaMask or other injected web3 and on ganache then try to connect to local ganache directly
-    if (targetedNetwork() === "ganache" && !(window as any).web3 && !(window as any).ethereum) {
+    /**
+     * If not MetaMask or other injected web3 and on ganache then try to connect to local ganache directly.
+     * Note we're going to ignore any injected web3 in favor of using our own preferred version of Web3.
+     */
+    if (!selectedProvider && (targetedNetwork() === "ganache" && !(window as any).ethereum)) {
       selectedProvider = new Web3(settings.ganache.web3Provider);
-      return true;
     }
 
     if (!selectedProvider) {

--- a/src/arc.ts
+++ b/src/arc.ts
@@ -310,16 +310,7 @@ async function enableWeb3Provider(): Promise<void> {
   if (!web3Modal) {
     _web3Modal = new Web3Modal({
       cacheProvider: true,
-      providerOptions: Object.assign(
-        /**
-         * This will hide the web3connect fallback ("Web3") button which currently
-         * doesn't behave well when there is no available extension.  The fallback is
-         * apparently "for injected providers that haven't been added to the library or
-         * that don't support the normal specification. Opera is an example of it."
-         * [UPDATE:]  Opera has been added to Web3Modal.
-         */
-        { disableInjectedProvider: !(window as any).ethereum },
-        getArcSettings().web3ConnectProviderOptions) as any,
+      providerOptions: getArcSettings().web3ConnectProviderOptions,
     });
 
     // eslint-disable-next-line require-atomic-updates

--- a/src/lib/util.ts
+++ b/src/lib/util.ts
@@ -269,7 +269,7 @@ export async function getNetworkId(web3Provider?: any): Promise<string> {
 
   try {
     arc = getArc();
-  } catch (ex) {
+  } catch {
     // Do nothing
   }
 


### PR DESCRIPTION
Resolves: https://github.com/daostack/alchemy/issues/1828

For the full set of changes and recommendations from MetaMask, see: https://medium.com/metamask/breaking-changes-to-the-metamask-inpage-provider-b4dde069dd0a

Latest status on these changes: https://github.com/MetaMask/metamask-extension/issues/8077#issuecomment-622191567. The changes have not yet taken effect.

This PR is reducing our exposure to window.web3 in general, preferring to use our version of preference, though frankly there wasn't much exposure to eliminate. Just two cases are affected by these changes:

1. when using ganache and both injected windows.web3 and injected windows.ethereum are absent, the choice whether to instantiate our own Web3. We now only look at whether an injected windows.ethereum is absent. So even if window.web3 is present, we will instantiate our preferred version of Web3.
1. when both injected windows.web3 and injected windows.ethereum are absent, tell Web3Modal not to display its fallback provider. We no longer worry about disabling that feature since in Web3Modal Opera no longer qualifies as injected, and thus this is not longer an issue.

Apparently Web3Modal is fully prepared for the MetaMask changes.

Note that MetaMask is supporting https://eips.ethereum.org/EIPS/eip-1193, and [recommends using it and describes how to use it](https://medium.com/metamask/breaking-changes-to-the-metamask-inpage-provider-b4dde069dd0a), though their docs are not complete on it (such as on [the need to use the request method due to abberant behavior by web3 1.xxx](https://github.com/MetaMask/metamask-extension/issues/8077#issuecomment-625927378)). Other providers are apparently still not consistent on their adoption of the standard. But at some point we should evaluate whether the providers we care about do, and when we find that they do, leverage the standard for ourselves, particularly in how we detect network and account changes.

Note also that MetaMask repeatedly recommends using ethers, not web3. Given that arc.js is centered on ethers, it might make further sense for Alchemy to do so as well.  I wonder if the ethers package is smaller than the web3 dependency?
