### PR TITLE
added plugins UI names

### DIFF
--- a/src/components/Dao/DaoPluginsPage.tsx
+++ b/src/components/Dao/DaoPluginsPage.tsx
@@ -6,7 +6,7 @@ import TrainingTooltip from "components/Shared/TrainingTooltip";
 import withSubscription, { ISubscriptionProps } from "components/Shared/withSubscription";
 import UnknownPluginCard from "components/Dao/UnknownPluginCard";
 import Analytics from "lib/analytics";
-import { getPluginIsActive, KNOWN_PLUGIN_NAMES, PROPOSAL_PLUGIN_NAMES } from "lib/pluginUtils";
+import { getPluginIsActive, PLUGIN_NAMES } from "lib/pluginUtils";
 import { Page } from "pages";
 import * as React from "react";
 import { BreadcrumbsItem } from "react-breadcrumbs-dynamic";
@@ -76,8 +76,8 @@ class DaoPluginsPage extends React.Component<IProps, null> {
     const allPlugins = data[0];
 
     const contributionReward = allPlugins.filter((plugin: AnyPlugin) => plugin.coreState.name === "ContributionReward");
-    const knownPlugins = allPlugins.filter((plugin: AnyPlugin) => plugin.coreState.name !== "ContributionReward" && KNOWN_PLUGIN_NAMES.indexOf(plugin.coreState.name) >= 0);
-    const unknownPlugins = allPlugins.filter((plugin: AnyPlugin) => KNOWN_PLUGIN_NAMES.indexOf(plugin.coreState.name) === -1 );
+    const knownPlugins = allPlugins.filter((plugin: AnyPlugin) => plugin.coreState.name !== "ContributionReward" && Object.keys(PLUGIN_NAMES).indexOf(plugin.coreState.name) >= 0);
+    const unknownPlugins = allPlugins.filter((plugin: AnyPlugin) => Object.keys(PLUGIN_NAMES).indexOf(plugin.coreState.name) === -1 );
     const allKnownPlugins = [...contributionReward, ...knownPlugins];
 
     const pluginManager = data[1];
@@ -87,7 +87,7 @@ class DaoPluginsPage extends React.Component<IProps, null> {
       <TransitionGroup>
         { allKnownPlugins.map((plugin: AnyPlugin) => (
           <Fade key={"plugin " + plugin.id}>
-            {PROPOSAL_PLUGIN_NAMES.includes(plugin.coreState.name)
+            {Object.keys(PLUGIN_NAMES).includes(plugin.coreState.name)
               ?
               <ProposalPluginCard daoState={daoState} pluginState={plugin.coreState} />
               : <SimplePluginCard daoState={daoState} pluginState={plugin.coreState} />

--- a/src/components/Plugin/PluginContainer.tsx
+++ b/src/components/Plugin/PluginContainer.tsx
@@ -5,7 +5,7 @@ import { getArc } from "arc";
 import classNames from "classnames";
 import Loading from "components/Shared/Loading";
 import withSubscription, { ISubscriptionProps } from "components/Shared/withSubscription";
-import { pluginName, getPluginIsActive, PROPOSAL_PLUGIN_NAMES } from "lib/pluginUtils";
+import { pluginName, getPluginIsActive, PLUGIN_NAMES } from "lib/pluginUtils";
 import * as React from "react";
 import { BreadcrumbsItem } from "react-breadcrumbs-dynamic";
 import { Helmet } from "react-helmet";
@@ -114,7 +114,7 @@ class PluginContainer extends React.Component<IProps, IState> {
     }
 
     const isActive = getPluginIsActive(pluginState);
-    const isProposalPlugin = PROPOSAL_PLUGIN_NAMES.includes(pluginState.name);
+    const isProposalPlugin = Object.keys(PLUGIN_NAMES).includes(pluginState.name);
 
     const proposalsTabClass = classNames({
       [css.proposals]: true,

--- a/src/components/Proposal/Create/PluginForms/CreatePluginManagerProposal.tsx
+++ b/src/components/Proposal/Create/PluginForms/CreatePluginManagerProposal.tsx
@@ -10,7 +10,7 @@ import { createProposal } from "actions/arcActions";
 import { showNotification, NotificationStatus } from "reducers/notifications";
 import Analytics from "lib/analytics";
 import { isValidUrl } from "lib/util";
-import { GetPluginIsActiveActions, getPluginIsActive, REQUIRED_PLUGIN_PERMISSIONS, pluginNameAndAddress, PLUGIN_NAMES } from "lib/pluginUtils";
+import { GetPluginIsActiveActions, getPluginIsActive, REQUIRED_PLUGIN_PERMISSIONS, pluginNameAndAddress, PLUGIN_NAMES, PLUGINS_UI_NAMES } from "lib/pluginUtils";
 import { exportUrl, importUrlValues } from "lib/proposalUtils";
 import { ErrorMessage, Field, Form, Formik, FormikProps } from "formik";
 import classNames from "classnames";
@@ -652,8 +652,8 @@ class CreatePluginManagerProposal extends React.Component<IProps, IState> {
                         }}
                       >
                         <option value="">Select a plugin...</option>
-                        {Object.values(PLUGIN_NAMES).map((name, _i) => {
-                          return <option id={`option-${name}`} key={`add_plugin_${name}`} value={name}>{name}</option>;
+                        {Object.values(PLUGIN_NAMES).map((name: keyof typeof PLUGIN_NAMES, _i) => {
+                          return <option id={`option-${name}`} key={`add_plugin_${name}`} value={name}>{PLUGINS_UI_NAMES[name]}</option>;
                         })}
                       </Field>
                     </div>

--- a/src/components/Proposal/Create/PluginForms/CreatePluginManagerProposal.tsx
+++ b/src/components/Proposal/Create/PluginForms/CreatePluginManagerProposal.tsx
@@ -10,7 +10,7 @@ import { createProposal } from "actions/arcActions";
 import { showNotification, NotificationStatus } from "reducers/notifications";
 import Analytics from "lib/analytics";
 import { isValidUrl } from "lib/util";
-import { GetPluginIsActiveActions, getPluginIsActive, REQUIRED_PLUGIN_PERMISSIONS, pluginNameAndAddress, PLUGIN_NAMES, PLUGINS_UI_NAMES } from "lib/pluginUtils";
+import { GetPluginIsActiveActions, getPluginIsActive, REQUIRED_PLUGIN_PERMISSIONS, pluginNameAndAddress, PLUGIN_NAMES } from "lib/pluginUtils";
 import { exportUrl, importUrlValues } from "lib/proposalUtils";
 import { ErrorMessage, Field, Form, Formik, FormikProps } from "formik";
 import classNames from "classnames";
@@ -652,8 +652,8 @@ class CreatePluginManagerProposal extends React.Component<IProps, IState> {
                         }}
                       >
                         <option value="">Select a plugin...</option>
-                        {Object.values(PLUGIN_NAMES).map((name: keyof typeof PLUGIN_NAMES, _i) => {
-                          return <option id={`option-${name}`} key={`add_plugin_${name}`} value={name}>{PLUGINS_UI_NAMES[name]}</option>;
+                        {Object.entries(PLUGIN_NAMES).map(([name, uiName]) => {
+                          return <option id={`option-${name}`} key={`add_plugin_${name}`} value={name}>{uiName}</option>;
                         })}
                       </Field>
                     </div>

--- a/src/lib/pluginUtils.ts
+++ b/src/lib/pluginUtils.ts
@@ -46,34 +46,13 @@ export const REQUIRED_PLUGIN_PERMISSIONS: any = {
 
 /** plugins that we know how to interpret  */
 export const PLUGIN_NAMES = {
-  ContributionReward: "ContributionReward",
-  GenericScheme: "GenericScheme",
-  ReputationFromToken: "ReputationFromToken",
-  SchemeRegistrar: "SchemeRegistrar",
-  SchemeFactory: "SchemeFactory",
-  Competition: "Competition",
-  ContributionRewardExt: "ContributionRewardExt",
-};
-
-export const KNOWN_PLUGIN_NAMES = Object.values(PLUGIN_NAMES);
-
-export const PROPOSAL_PLUGIN_NAMES = [
-  "ContributionReward",
-  "GenericScheme",
-  "SchemeRegistrar",
-  "Competition",
-  "SchemeFactory",
-  "ContributionRewardExt",
-];
-
-export const PLUGINS_UI_NAMES = {
   ContributionReward: "Funding and Voting Power",
-  GenericScheme: "GenericScheme",
-  ReputationFromToken: "ReputationFromToken",
-  SchemeRegistrar: "SchemeRegistrar",
+  GenericScheme: "Generic Plugin",
+  ReputationFromToken: "Reputation from Token",
+  SchemeRegistrar: "Plugin Registrar",
   SchemeFactory: "Plugin Manager",
   Competition: "Competition",
-  ContributionRewardExt: "ContributionRewardExt",
+  ContributionRewardExt: "Contribution Reward Ext",
 };
 
 /**
@@ -93,7 +72,7 @@ export function isKnownPlugin(address: Address) {
     throw err;
   }
 
-  if (KNOWN_PLUGIN_NAMES.includes(contractInfo.name)) {
+  if (Object.keys(PLUGIN_NAMES).includes(contractInfo.name)) {
     return true;
   } else {
     return false;
@@ -119,25 +98,20 @@ export function pluginName(plugin: IPluginState|IContractInfo, fallback?: string
       // this should never happen...
       name = "Blockchain Interaction";
     }
-  } else if (plugin.name === "ContributionReward") {
-    name ="Funding and Voting Power";
-  } else if (plugin.name === "SchemeRegistrar") {
-    name ="Plugin Registrar";
-  } else if (plugin.name === "SchemeFactory") {
-    name ="Plugin Manager";
-  } else if (plugin.name) {
-    if (plugin.name === "ContributionRewardExt") {
-      name = rewarderContractName(plugin as IContributionRewardExtState);
+  } else if (plugin.name === "ContributionRewardExt") {
+    name = rewarderContractName(plugin as IContributionRewardExtState);
 
-      if (!name) {
-        name = "ContributionRewardExt";
-      }
+    if (!name) {
+      name = "ContributionRewardExt";
     } else {
       // add spaces before capital letters to approximate a human-readable title
       name = `${plugin.name[0]}${plugin.name.slice(1).replace(/([A-Z])/g, " $1")}`;
     }
   } else {
-    name = fallback;
+    name = PLUGIN_NAMES[plugin.name as keyof typeof PLUGIN_NAMES];
+    if (name === undefined){
+      name = fallback;
+    }
   }
   return name;
 }

--- a/src/lib/pluginUtils.ts
+++ b/src/lib/pluginUtils.ts
@@ -66,6 +66,16 @@ export const PROPOSAL_PLUGIN_NAMES = [
   "ContributionRewardExt",
 ];
 
+export const PLUGINS_UI_NAMES = {
+  ContributionReward: "Funding and Voting Power",
+  GenericScheme: "GenericScheme",
+  ReputationFromToken: "ReputationFromToken",
+  SchemeRegistrar: "SchemeRegistrar",
+  SchemeFactory: "Plugin Manager",
+  Competition: "Competition",
+  ContributionRewardExt: "ContributionRewardExt",
+};
+
 /**
  * return true if the address is the address of a known plugin (which we know how to represent)
  * @param  address [description]


### PR DESCRIPTION
It's not possible just to change the names of the plugins since the names themselves are used in more places not just as display names but as dom objects IDs, keys and more.
Instead, I created a new object called: `PLUGINS_UI_NAMES`. Here we can give the display name to each plugin without affecting the IDs, keys and more.