### PR TITLE
Updating daocreator experimental package to set redirect link from alchemy

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2763,9 +2763,9 @@
       }
     },
     "@dorgtech/daocreator-ui-experimental": {
-      "version": "1.1.9",
-      "resolved": "https://registry.npmjs.org/@dorgtech/daocreator-ui-experimental/-/daocreator-ui-experimental-1.1.9.tgz",
-      "integrity": "sha512-K5w5fz1SDtuXl3brt+pZHNDj5kYZh15Fn3zW3a8B9IQuYuZkaw66zCvAr3zcdxPCOH0n9NBYxh6wET9wlV0scg==",
+      "version": "1.1.10",
+      "resolved": "https://registry.npmjs.org/@dorgtech/daocreator-ui-experimental/-/daocreator-ui-experimental-1.1.10.tgz",
+      "integrity": "sha512-4d09id0SZtm2Bf/K2WAk4lcW8Kd0ltqP0bNnYFuCpSRdf/fFnTtQLHKYo3vxRCx5EI39dx+IxosJFDpt4VfyoA==",
       "requires": {
         "@date-io/core": "^1.3.6",
         "@date-io/date-fns": "^1.3.11",

--- a/package-lock.json
+++ b/package-lock.json
@@ -2763,9 +2763,9 @@
       }
     },
     "@dorgtech/daocreator-ui-experimental": {
-      "version": "1.1.7",
-      "resolved": "https://registry.npmjs.org/@dorgtech/daocreator-ui-experimental/-/daocreator-ui-experimental-1.1.7.tgz",
-      "integrity": "sha512-MXsTSs5wrCdDGt8j7hGh0G6UFYYOLDQSgMHX9oGK7PM+KZ/sjI3Z75BEaDcCiSt5V7oMzUNmN3/dTU43wg1MFg==",
+      "version": "1.1.9",
+      "resolved": "https://registry.npmjs.org/@dorgtech/daocreator-ui-experimental/-/daocreator-ui-experimental-1.1.9.tgz",
+      "integrity": "sha512-K5w5fz1SDtuXl3brt+pZHNDj5kYZh15Fn3zW3a8B9IQuYuZkaw66zCvAr3zcdxPCOH0n9NBYxh6wET9wlV0scg==",
       "requires": {
         "@date-io/core": "^1.3.6",
         "@date-io/date-fns": "^1.3.11",
@@ -20179,9 +20179,9 @@
       }
     },
     "hyphenate-style-name": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/hyphenate-style-name/-/hyphenate-style-name-1.0.3.tgz",
-      "integrity": "sha512-EcuixamT82oplpoJ2XU4pDtKGWQ7b00CD9f1ug9IaQ3p1bkHMiKCZ9ut9QDI6qsa6cpUuB+A/I+zLtdNK4n2DQ=="
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/hyphenate-style-name/-/hyphenate-style-name-1.0.4.tgz",
+      "integrity": "sha512-ygGZLjmXfPHj+ZWh6LwbC37l43MhfztxetbFCoYTM2VjkIUpeHgSNn7QIyVFj7YQ1Wl9Cbw5sholVJPzWvC2MQ=="
     },
     "iconv-lite": {
       "version": "0.4.24",

--- a/package.json
+++ b/package.json
@@ -80,7 +80,7 @@
     "3box": "1.17.1",
     "@burner-wallet/burner-connect-provider": "^0.1.1",
     "@daostack/arc.js": "^2.0.0-experimental.45",
-    "@dorgtech/daocreator-ui-experimental": "1.1.9",
+    "@dorgtech/daocreator-ui-experimental": "1.1.10",
     "@fortawesome/fontawesome-svg-core": "^1.2.10",
     "@fortawesome/free-brands-svg-icons": "^5.6.1",
     "@fortawesome/react-fontawesome": "^0.1.3",

--- a/package.json
+++ b/package.json
@@ -80,7 +80,7 @@
     "3box": "1.17.1",
     "@burner-wallet/burner-connect-provider": "^0.1.1",
     "@daostack/arc.js": "^2.0.0-experimental.45",
-    "@dorgtech/daocreator-ui-experimental": "1.1.7",
+    "@dorgtech/daocreator-ui-experimental": "1.1.9",
     "@fortawesome/fontawesome-svg-core": "^1.2.10",
     "@fortawesome/free-brands-svg-icons": "^5.6.1",
     "@fortawesome/react-fontawesome": "^0.1.3",

--- a/src/components/DaoCreator/index.tsx
+++ b/src/components/DaoCreator/index.tsx
@@ -48,7 +48,7 @@ class DaoCreator extends React.Component<IProps> {
             return await getWeb3Provider();
           }}
           noDAOstackLogo
-          redirectURL="https://alchemy-xdai.daostack.io"
+          redirectURL={process.env.BASE_URL}
         />
       </React.Suspense>
     );

--- a/src/components/DaoCreator/index.tsx
+++ b/src/components/DaoCreator/index.tsx
@@ -48,6 +48,7 @@ class DaoCreator extends React.Component<IProps> {
             return await getWeb3Provider();
           }}
           noDAOstackLogo
+          redirectURL="https://alchemy-xdai.daostack.io"
         />
       </React.Suspense>
     );


### PR DESCRIPTION
I added an example on how you should set the URL via props. Now you can, based on the `targetedNetwork`, define where you want to redirect the user when they create a new DAO.

Note: The props just needs the domain (like in the example I did), the rest is handled by daocreator, you can check the code here: https://github.com/dOrgTech/DAOcreator/blob/issue-509-dynamic_link_on_deployment/packages/ui_v2/src/components/commonV2/dao/Migrator/DeployButton.tsx#L452
