### PR TITLE
expose alchemy version number

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -7,8 +7,16 @@ assignees: ''
 
 ---
 
+**Include the Alchemy Version Number**
+Please include the Alchemy version number, which you may obtain as follows:
+
+1. hover your mouse over the Alchemy logo image in the upper left corner of any page in Alchemy. A tooltip will appear below the icon which will contain the Alchemy version number.
+2. in the tooltip, select the version number, copy it to your clipboard and paste it into this bug report.
+
+Thanks!
+
 **Describe the bug**
-A clear and concise description of what the bug is.
+A clear and concise description of the bug.
 
 **To Reproduce**
 Steps to reproduce the behavior:

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -23,8 +23,8 @@ A clear and concise description of what you expected to happen.
 **Alchemy Version Number**
 You may obtain the Alchemy version number as follows:
 
-1. hover your mouse over the Alchemy logo image in the upper left corner of any page in Alchemy. A tooltip will appear below the icon which will contain the Alchemy version number.
-2. in the tooltip, select the version number, copy it to your clipboard and paste it into this bug report.
+1. Hover your mouse over the Alchemy logo image in the upper left corner of any page in Alchemy. Below the icon a tooltip will appear which will contain the Alchemy version number.
+2. In the tooltip, select the version number, copy it to your clipboard and paste it into this bug report.
 
 **Screenshots**
 If applicable, add screenshots to help explain your problem.

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -7,14 +7,6 @@ assignees: ''
 
 ---
 
-**Include the Alchemy Version Number**
-Please include the Alchemy version number, which you may obtain as follows:
-
-1. hover your mouse over the Alchemy logo image in the upper left corner of any page in Alchemy. A tooltip will appear below the icon which will contain the Alchemy version number.
-2. in the tooltip, select the version number, copy it to your clipboard and paste it into this bug report.
-
-Thanks!
-
 **Describe the bug**
 A clear and concise description of the bug.
 
@@ -27,6 +19,12 @@ Steps to reproduce the behavior:
 
 **Expected behavior**
 A clear and concise description of what you expected to happen.
+
+**Alchemy Version Number**
+You may obtain the Alchemy version number as follows:
+
+1. hover your mouse over the Alchemy logo image in the upper left corner of any page in Alchemy. A tooltip will appear below the icon which will contain the Alchemy version number.
+2. in the tooltip, select the version number, copy it to your clipboard and paste it into this bug report.
 
 **Screenshots**
 If applicable, add screenshots to help explain your problem.

--- a/src/layouts/Header.tsx
+++ b/src/layouts/Header.tsx
@@ -24,7 +24,6 @@ import { Address, IDAOState } from "@daostack/arc.js";
 import { ETHDENVER_OPTIMIZATION } from "../settings";
 import * as css from "./App.scss";
 import ProviderConfigButton from "layouts/ProviderConfigButton";
-import axios from "axios";
 import Tooltip from "rc-tooltip";
 
 interface IExternalProps extends RouteComponentProps<any> {
@@ -118,7 +117,7 @@ class Header extends React.Component<IProps, ILocalStateProps> {
       };
     }
 
-    this.setState({ alchemyVersion: (await axios("https://raw.githubusercontent.com/daostack/alchemy/master-2/package.json"))?.data?.version ?? "Not found" });
+    this.setState({ alchemyVersion: PACKAGE_VERSION ?? "Not found" });
   }
 
   public handleClickLogin = async (_event: any): Promise<void> => {

--- a/src/layouts/Header.tsx
+++ b/src/layouts/Header.tsx
@@ -29,7 +29,7 @@ import Tooltip from "rc-tooltip";
 interface IExternalProps extends RouteComponentProps<any> {
 }
 
-interface IExternalStateProps {
+interface IStateProps {
   showRedemptionsButton: boolean;
   currentAccountProfile: IProfileState;
   currentAccountAddress: string | null;
@@ -38,11 +38,7 @@ interface IExternalStateProps {
   threeBox: any;
 }
 
-interface ILocalStateProps {
-  alchemyVersion: string;
-}
-
-const mapStateToProps = (state: IRootState & IExternalStateProps, ownProps: IExternalProps): IExternalProps & IExternalStateProps => {
+const mapStateToProps = (state: IRootState & IStateProps, ownProps: IExternalProps): IExternalProps & IStateProps => {
   const match = matchPath(ownProps.location.pathname, {
     path: "/dao/:daoAvatarAddress",
     strict: false,
@@ -91,23 +87,20 @@ const mapDispatchToProps = {
   threeBoxLogout,
 };
 
-type IProps = IExternalProps & IExternalStateProps & IDispatchProps & ISubscriptionProps<IDAOState>;
+type IProps = IExternalProps & IStateProps & IDispatchProps & ISubscriptionProps<IDAOState>;
 
-class Header extends React.Component<IProps, ILocalStateProps> {
+class Header extends React.Component<IProps, null> {
 
   constructor(props: IProps) {
     super(props);
     this.toggleDiv = React.createRef();
     this.initializeTrainingTooltipsToggle();
-    this.state = {
-      alchemyVersion: "",
-    };
   }
 
   private static trainingTooltipsEnabledKey = "trainingTooltipsEnabled";
   private toggleDiv: RefObject<HTMLDivElement>;
 
-  public async componentDidMount() {
+  public componentDidMount() {
     if (this.toggleDiv.current) {
       this.toggleDiv.current.onmouseenter = (_ev: MouseEvent) => {
         this.props.enableTrainingTooltipsShowAll();
@@ -192,7 +185,7 @@ class Header extends React.Component<IProps, ILocalStateProps> {
               <img src="/assets/images/Icon/Close.svg"/> :
               <img src="/assets/images/Icon/Menu.svg"/>}
           </div>
-          <Tooltip overlay={`DAOstack Alchemy version: ${this.state.alchemyVersion}`} placement="bottomRight">
+          <Tooltip overlay={`DAOstack Alchemy version: ${PACKAGE_VERSION ?? "Not found"}`} placement="bottomRight">
             <div className={css.menu}>
               <Link to="/">
                 <img src="/assets/images/alchemy-logo-white.svg"/>

--- a/src/layouts/Header.tsx
+++ b/src/layouts/Header.tsx
@@ -24,11 +24,13 @@ import { Address, IDAOState } from "@daostack/arc.js";
 import { ETHDENVER_OPTIMIZATION } from "../settings";
 import * as css from "./App.scss";
 import ProviderConfigButton from "layouts/ProviderConfigButton";
+import axios from "axios";
+import Tooltip from "rc-tooltip";
 
 interface IExternalProps extends RouteComponentProps<any> {
 }
 
-interface IStateProps {
+interface IExternalStateProps {
   showRedemptionsButton: boolean;
   currentAccountProfile: IProfileState;
   currentAccountAddress: string | null;
@@ -37,7 +39,11 @@ interface IStateProps {
   threeBox: any;
 }
 
-const mapStateToProps = (state: IRootState & IStateProps, ownProps: IExternalProps): IExternalProps & IStateProps => {
+interface ILocalStateProps {
+  alchemyVersion: string;
+}
+
+const mapStateToProps = (state: IRootState & IExternalStateProps, ownProps: IExternalProps): IExternalProps & IExternalStateProps => {
   const match = matchPath(ownProps.location.pathname, {
     path: "/dao/:daoAvatarAddress",
     strict: false,
@@ -86,20 +92,23 @@ const mapDispatchToProps = {
   threeBoxLogout,
 };
 
-type IProps = IExternalProps & IStateProps & IDispatchProps & ISubscriptionProps<IDAOState>;
+type IProps = IExternalProps & IExternalStateProps & IDispatchProps & ISubscriptionProps<IDAOState>;
 
-class Header extends React.Component<IProps, null> {
+class Header extends React.Component<IProps, ILocalStateProps> {
 
   constructor(props: IProps) {
     super(props);
     this.toggleDiv = React.createRef();
     this.initializeTrainingTooltipsToggle();
+    this.state = {
+      alchemyVersion: "",
+    };
   }
 
   private static trainingTooltipsEnabledKey = "trainingTooltipsEnabled";
   private toggleDiv: RefObject<HTMLDivElement>;
 
-  public componentDidMount() {
+  public async componentDidMount() {
     if (this.toggleDiv.current) {
       this.toggleDiv.current.onmouseenter = (_ev: MouseEvent) => {
         this.props.enableTrainingTooltipsShowAll();
@@ -108,6 +117,8 @@ class Header extends React.Component<IProps, null> {
         this.props.disableTrainingTooltipsShowAll();
       };
     }
+
+    this.setState({ alchemyVersion: (await axios("https://raw.githubusercontent.com/daostack/alchemy/master-2/package.json"))?.data?.version ?? "Not found" });
   }
 
   public handleClickLogin = async (_event: any): Promise<void> => {
@@ -182,13 +193,13 @@ class Header extends React.Component<IProps, null> {
               <img src="/assets/images/Icon/Close.svg"/> :
               <img src="/assets/images/Icon/Menu.svg"/>}
           </div>
-          <TrainingTooltip overlay="View your personal feed" placement="bottomRight">
+          <Tooltip overlay={`DAOstack Alchemy version: ${this.state.alchemyVersion}`} placement="bottomRight">
             <div className={css.menu}>
               <Link to="/">
                 <img src="/assets/images/alchemy-logo-white.svg"/>
               </Link>
             </div>
-          </TrainingTooltip>
+          </Tooltip>
           <div className={css.topInfo}>
             <Breadcrumbs
               separator={<b> &gt;   </b>}

--- a/typings/build.d.ts
+++ b/typings/build.d.ts
@@ -1,2 +1,2 @@
-declare const VERSION: string;
+declare const PACKAGE_VERSION: string;
 declare const TOKENS: { [symbol: string]: string };

--- a/webpack.base.config.js
+++ b/webpack.base.config.js
@@ -119,7 +119,7 @@ module.exports = {
       template: "src/index.html"
     }),
     new webpack.DefinePlugin({
-      VERSION: JSON.stringify(require("./package.json").version)
+      PACKAGE_VERSION: JSON.stringify(require("./package.json").version)
     }),
     new webpack.IgnorePlugin(/^\.\/locale$/, /moment$/),
     new MiniCssExtractPlugin()


### PR DESCRIPTION
Resolves: https://github.com/daostack/alchemy/issues/1900https://github.com/daostack/alchemy/issues/1900

* puts the version number in a new tooltip over Alchemy icon in the header
* removes the existing TrainingTooltip that was obsolete and incorrect
* obtains the version number using https from github in the package.json of the master-2 branch
  * note that unique patch versions might not be reflected in the master branch
  * if desired, this could be made to pull the version from dev-2 for staging/review apps
* adds instructions on using the version in the github bug template
* should we do this for Alchemy 1.0 too?  @orenyodfat 