### PR TITLE
handle all arc.js datetime types

### DIFF
--- a/src/components/Plugin/ContributionRewardExtRewarders/Competition/utils.ts
+++ b/src/components/Plugin/ContributionRewardExtRewarders/Competition/utils.ts
@@ -8,6 +8,7 @@ import { operationNotifierObserver } from "actions/arcActions";
 import { IRootState } from "reducers";
 import { Observable, of } from "rxjs";
 import { map, mergeMap, toArray, first } from "rxjs/operators";
+import { safeMoment } from "lib/util";
 
 /**
  * Defined in the order that Competition cards should be sorted in the List component.
@@ -72,10 +73,10 @@ export class CompetitionStatus {
 
 export const competitionStatus = (competition: ICompetitionProposalState): CompetitionStatus => {
   const now = moment();
-  const startTime = moment(competition.startTime);
-  const submissionsEndTime = moment(competition.suggestionsEndTime);
-  const votingStartTime = moment(competition.votingStartTime);
-  const endTime = moment(competition.endTime);
+  const startTime = safeMoment(competition.startTime);
+  const submissionsEndTime = safeMoment(competition.suggestionsEndTime);
+  const votingStartTime = safeMoment(competition.votingStartTime);
+  const endTime = safeMoment(competition.endTime);
   const hasSubmissions = !!competition.totalSuggestions;
   const hasWinners = !!competition.numberOfWinningSuggestions;
   let status: CompetitionStatusEnum;

--- a/src/components/Proposal/Voting/VoteButtons.tsx
+++ b/src/components/Proposal/Voting/VoteButtons.tsx
@@ -7,7 +7,7 @@ import classNames from "classnames";
 import Reputation from "components/Account/Reputation";
 import { ActionTypes, default as PreTransactionModal } from "components/Shared/PreTransactionModal";
 import Analytics from "lib/analytics";
-import { fromWei, targetedNetwork } from "lib/util";
+import { fromWei, targetedNetwork, safeMoment } from "lib/util";
 import { Page } from "pages";
 import * as React from "react";
 import { connect } from "react-redux";
@@ -105,7 +105,7 @@ class VoteButtons extends React.Component<IProps, IState> {
                             (proposalState.stage === IProposalStage.Boosted && expired) ||
                             (proposalState.stage === IProposalStage.QuietEndingPeriod && expired) ||
                             (currentAccountState && currentAccountState.reputation.eq(new BN(0))) ||
-                            (currentAccountState && (proposalState.createdAt < currentAccountState.createdAt) &&
+                            (currentAccountState && (safeMoment(proposalState.createdAt) < safeMoment(currentAccountState.createdAt)) &&
                             //this is a workaround till https://github.com/daostack/subgraph/issues/548
                             (targetedNetwork() !== "ganache")) ||
                             currentVote === IProposalOutcome.Pass ||
@@ -133,7 +133,7 @@ class VoteButtons extends React.Component<IProps, IState> {
            * 5) when `currentAccount` is not found in the subgraph, then a fake `currentAccountState` is created with
            * rep == 0
            */
-          (currentAccountState && (proposalState.createdAt < currentAccountState.createdAt)) ?
+          (currentAccountState && (safeMoment(proposalState.createdAt) < safeMoment(currentAccountState.createdAt))) ?
             "Must have had reputation in this DAO when the proposal was created" :
             proposalState.stage === IProposalStage.ExpiredInQueue ||
                 (proposalState.stage === IProposalStage.Boosted && expired) ||

--- a/src/lib/proposalUtils.ts
+++ b/src/lib/proposalUtils.ts
@@ -3,7 +3,7 @@ import moment = require("moment-timezone");
 
 const cloneDeep = require("clone-deep");
 
-export function importUrlValues<Values>(defaultValues: Values) {
+export function importUrlValues<Values>(defaultValues: Values): any {
   const { search } = window.location;
   const params = new URLSearchParams(search);
   const initialFormValues: any = cloneDeep([defaultValues])[0];
@@ -41,14 +41,14 @@ export function importUrlValues<Values>(defaultValues: Values) {
   return initialFormValues;
 }
 
-export const exportUrl = (values: any) => {
-  const setQueryString = (key: string) => {
+export const exportUrl = (values: unknown): void => {
+  const setQueryString = (key: keyof typeof values): string => {
     if (values[key] === undefined) {
       return "";
     }
     if (typeof values[key] === "object") {
       if (moment.isMoment(values[key])) {
-        return `${key}=${values[key].toString()}`;
+        return `${key}=${(values[key] as moment.Moment).toString()}`;
       } else {
         return `${key}=${JSON.stringify(values[key])}`;
       }

--- a/src/lib/util.ts
+++ b/src/lib/util.ts
@@ -652,6 +652,7 @@ export function safeMoment(dateSpecifier: moment.Moment | Date | number | string
     case "string":
       return moment(dateSpecifier);
     case "number":
+      // then should be a count of seconds in UNIX epoch
       return moment.unix(dateSpecifier);
     default:
       throw new Error(`safeMoment: unknown type: ${typeof dateSpecifier}`);

--- a/src/lib/util.ts
+++ b/src/lib/util.ts
@@ -638,14 +638,11 @@ export function ethBalance(address: Address): Observable<BN> {
 /**
  * arc.js is inconsistent in how it returns datetimes.
  * Convert all possibilities safely to a `moment`.
- * Is also OK when the dateSpecifier is already a moment
+ * Is OK when the dateSpecifier is already a moment.
+ * If is a string, must be ISO-conformant.
  * @param dateSpecifier
  */
-export function safeMoment(dateSpecifier: moment.Moment | Date | number | string | undefined): moment.Moment | null {
-  if (!dateSpecifier) {
-    return null;
-  }
-
+export function safeMoment(dateSpecifier: moment.Moment | Date | number | string | undefined): moment.Moment {
   switch (typeof dateSpecifier) {
     case "object":
       if (moment.isMoment(dateSpecifier)) {

--- a/src/lib/util.ts
+++ b/src/lib/util.ts
@@ -301,7 +301,7 @@ export async function getNetworkId(web3Provider?: Web3Provider): Promise<string>
       return network.chainId.toString();
     } else {
       const promise = new Promise<string>((resolve, reject) => {
-        web3Provider.send("net_version", (error, response) => {
+        web3Provider.send("net_version", (error: any, response: any) => {
           if (error) {
             reject(error);
           } else {
@@ -633,4 +633,30 @@ export function ethBalance(address: Address): Observable<BN> {
 
   const arc = getArc();
   return arc.ethBalance(address);
+}
+
+/**
+ * arc.js is inconsistent in how it returns datetimes.
+ * Convert all possibilities safely to a `moment`.
+ * Is also OK when the dateSpecifier is already a moment
+ * @param dateSpecifier
+ */
+export function safeMoment(dateSpecifier: moment.Moment | Date | number | string | undefined): moment.Moment | null {
+  if (!dateSpecifier) {
+    return null;
+  }
+
+  switch (typeof dateSpecifier) {
+    case "object":
+      if (moment.isMoment(dateSpecifier)) {
+        return dateSpecifier;
+      }
+      // else assume is a Date, fallthrough
+    case "string":
+      return moment(dateSpecifier);
+    case "number":
+      return moment.unix(dateSpecifier);
+    default:
+      throw new Error(`safeMoment: unknown type: ${typeof dateSpecifier}`);
+  }
 }


### PR DESCRIPTION
Resolves: https://github.com/daostack/alchemy/issues/1984

* Adds `safeMoment`.
* a couple other tweaks to attempt to ensure we're safe from any changes to arc.js wrt datetime typing
  * where Competition computes its status with respect to its workflow
  * where the vote buttons compute whether the proposal was created before the account had rep in the DAO