### PR TITLE
Fix Enable Prediction button text overflows

### DIFF
--- a/src/components/Proposal/Staking/StakeButtons.scss
+++ b/src/components/Proposal/Staking/StakeButtons.scss
@@ -209,9 +209,10 @@
 
   .enablePredictions {
     button {
-      width: 120px;
-      white-space: nowrap;
+      width: fit-content;
       height: auto;
+      padding-left: 10px;
+      padding-right: 10px;
     }
   }
 }


### PR DESCRIPTION
resolves: https://github.com/daostack/alchemy/issues/2148

Robust styles to the Enable Predictions button to look good on both Windows and Mac.