### PR TITLE
Update condition to support Add and Replace plugin

### DIFF
--- a/src/components/Plugin/PluginInfoPage.tsx
+++ b/src/components/Plugin/PluginInfoPage.tsx
@@ -20,43 +20,75 @@ interface IExternalProps {
 
 type IProps = IExternalProps;
 
+export const renderGpParams = (params: IGenesisProtocolParams): any => {
+
+  const duration = (durationSeconds: number): any => {
+    if (!durationSeconds) {
+      return "";
+    }
+
+    const duration = moment.duration(durationSeconds * 1000);
+
+    const days = Math.floor(duration.asDays());
+    const hours = duration.hours();
+    const minutes = duration.minutes();
+    const seconds = duration.seconds();
+    // there won't ever be milliseconds
+    const colon = <span className={css.colon}>: </span>;
+
+    const first = days ? "days" : hours ? "hours" : minutes ? "minutes" : seconds ? "seconds" : null;
+
+    return <span>
+      {
+        days ? <span className={css.timeSection}><strong>{days} day{days > 1 ? "s" : ""}</strong></span> : ""
+      }
+      {
+        hours ? <span className={css.timeSection}>{first !== "hours" ? colon : ""}<strong>{hours} hour{hours > 1 ? "s" : ""}</strong></span> : ""
+      }
+      {
+        minutes ? <span className={css.timeSection}><span>{first !== "minutes" ? colon : ""}<strong>{minutes} minute{minutes > 1 ? "s" : ""}</strong></span></span> : ""
+      }
+      {
+        seconds ? <span className={css.timeSection}><span>{first !== "seconds" ? colon : ""}<strong>{seconds} second{seconds > 1 ? "s" : ""}</strong></span></span> : ""
+      }
+    </span>;
+  };
+
+  // represent time in locale-independent UTC format
+  const activationTime = moment.unix(params.activationTime).utc();
+
+  return <React.Fragment>
+    <div>Activation Time:</div><div className={css.ellipsis}>{
+      `${ activationTime.format("h:mm A [UTC] on MMMM Do, YYYY")} ${activationTime.isSameOrBefore(moment()) ? "(active)" : "(inactive)"}`
+    }</div>
+    <div>Boosted Vote Period Limit:</div><div>{duration(params.boostedVotePeriodLimit)} ({params.boostedVotePeriodLimit} seconds)</div>
+    <div>DAO Bounty Constant:</div><div>{params.daoBountyConst}</div>
+    <div>Proposal Reputation Reward:</div><div>{fromWei(params.proposingRepReward)} REP</div>
+    <div>Minimum DAO Bounty:</div><div>{fromWei(params.minimumDaoBounty)} GEN</div>
+    <div>Pre-Boosted Vote Period Limit:</div><div>{duration(params.preBoostedVotePeriodLimit)} ({params.preBoostedVotePeriodLimit} seconds)</div>
+    <div>Queued Vote Period Limit:</div><div>{duration(params.queuedVotePeriodLimit)} ({params.queuedVotePeriodLimit} seconds)</div>
+    <div>Queued Vote Required:</div><div>{params.queuedVoteRequiredPercentage}%</div>
+    <div>Quiet Ending Period:</div><div>{duration(params.quietEndingPeriod)} ({params.quietEndingPeriod} seconds)</div>
+    <div>Threshold Constant</div><div>
+      <Tooltip
+        placement="top"
+        overlay={
+          <span>{params.thresholdConst.toString()}</span>
+        }
+        trigger={["hover"]}
+      >
+        <span>{roundUp(params.thresholdConst, 3).toString()}</span>
+      </Tooltip>
+    </div>
+    <div>Voters Reputation Loss:</div><div>{params.votersReputationLossRatio}%</div>
+  </React.Fragment>;
+};
+
 export default class PluginInfo extends React.Component<IProps, null> {
 
   public render(): RenderOutput {
     const { daoState, plugin } = this.props;
     const daoAvatarAddress = daoState.address;
-
-    const duration = (durationSeconds: number): any => {
-      if (!durationSeconds) {
-        return "";
-      }
-
-      const duration = moment.duration(durationSeconds * 1000);
-
-      const days = Math.floor(duration.asDays());
-      const hours = duration.hours();
-      const minutes = duration.minutes();
-      const seconds = duration.seconds();
-      // there won't ever be milliseconds
-      const colon = <span className={css.colon}>: </span>;
-
-      const first = days ? "days" : hours ? "hours" : minutes ? "minutes" : seconds ? "seconds" : null;
-
-      return <span>
-        {
-          days ? <span className={css.timeSection}><strong>{days} day{days > 1 ? "s" : ""}</strong></span> : ""
-        }
-        {
-          hours ? <span className={css.timeSection}>{first !== "hours" ? colon : ""}<strong>{hours} hour{hours > 1 ? "s" : ""}</strong></span> : ""
-        }
-        {
-          minutes ? <span className={css.timeSection}><span>{first !== "minutes" ? colon : ""}<strong>{minutes} minute{minutes > 1 ? "s" : ""}</strong></span></span> : ""
-        }
-        {
-          seconds ? <span className={css.timeSection}><span>{first !== "seconds" ? colon : ""}<strong>{seconds} second{seconds > 1 ? "s" : ""}</strong></span></span> : ""
-        }
-      </span>;
-    };
 
     const renderVotingMachineLink = (votingMachine: Address) => {
       if (votingMachine) {
@@ -68,37 +100,7 @@ export default class PluginInfo extends React.Component<IProps, null> {
         </>;
       }
     };
-    const renderGpParams = (params: IGenesisProtocolParams): any => {
 
-      // represent time in locale-independent UTC format
-      const activationTime = moment.unix(params.activationTime).utc();
-
-      return <React.Fragment>
-        <div>Activation Time:</div><div className={css.ellipsis}>{
-          `${ activationTime.format("h:mm A [UTC] on MMMM Do, YYYY")} ${activationTime.isSameOrBefore(moment()) ? "(active)" : "(inactive)"}`
-        }</div>
-        <div>Boosted Vote Period Limit:</div><div>{duration(params.boostedVotePeriodLimit)} ({params.boostedVotePeriodLimit} seconds)</div>
-        <div>DAO Bounty Constant:</div><div>{params.daoBountyConst}</div>
-        <div>Proposal Reputation Reward:</div><div>{fromWei(params.proposingRepReward)} REP</div>
-        <div>Minimum DAO Bounty:</div><div>{fromWei(params.minimumDaoBounty)} GEN</div>
-        <div>Pre-Boosted Vote Period Limit:</div><div>{duration(params.preBoostedVotePeriodLimit)} ({params.preBoostedVotePeriodLimit} seconds)</div>
-        <div>Queued Vote Period Limit:</div><div>{duration(params.queuedVotePeriodLimit)} ({params.queuedVotePeriodLimit} seconds)</div>
-        <div>Queued Vote Required:</div><div>{params.queuedVoteRequiredPercentage}%</div>
-        <div>Quiet Ending Period:</div><div>{duration(params.quietEndingPeriod)} ({params.quietEndingPeriod} seconds)</div>
-        <div>Threshold Constant</div><div>
-          <Tooltip
-            placement="top"
-            overlay={
-              <span>{params.thresholdConst.toString()}</span>
-            }
-            trigger={["hover"]}
-          >
-            <span>{roundUp(params.thresholdConst, 3).toString()}</span>
-          </Tooltip>
-        </div>
-        <div>Voters Reputation Loss:</div><div>{params.votersReputationLossRatio}%</div>
-      </React.Fragment>;
-    };
 
     const pluginParams = (plugin as any).pluginParams;
     const votingMachine = (

--- a/src/components/Proposal/ProposalSummary/ProposalSummary.scss
+++ b/src/components/Proposal/ProposalSummary/ProposalSummary.scss
@@ -8,6 +8,16 @@
   text-align: center;
   font-family: "Open Sans";
 
+  .detailsRowsContainer {
+    display: grid;
+    grid-template-columns: 1.1fr 2fr;
+    column-gap: 16px;
+    row-gap: 4px;
+    > div:nth-child(odd) {
+      font-weight: bold;
+    }
+  }
+
   strong {
     font-weight: normal;
   }

--- a/src/components/Proposal/ProposalSummary/ProposalSummaryPluginManager.tsx
+++ b/src/components/Proposal/ProposalSummary/ProposalSummaryPluginManager.tsx
@@ -58,7 +58,7 @@ class ProposalSummary extends React.Component<IProps, IState> {
     const decodedData = proposalState.pluginToRegisterDecodedData;
     let votingParams;
     let contractToCall;
-    if ( pluginName && decodedData && pluginName !== "ReputationFromToken"){ // proposalState.pluginToRemove === NULL_ADDRESS // If Plugin to Add or Plugin to Replace
+    if (pluginName && decodedData && pluginName !== "ReputationFromToken"){ // pluginName && decodedData ---> means the plugin is Add or Replace (not Remove)
       votingParams = decodedData.params[2].value;
       if (pluginName === "GenericScheme"){
         contractToCall = decodedData.params[5].value;

--- a/src/components/Proposal/ProposalSummary/ProposalSummaryPluginManager.tsx
+++ b/src/components/Proposal/ProposalSummary/ProposalSummaryPluginManager.tsx
@@ -1,14 +1,15 @@
-import { IDAOState, IPluginManagerProposalState, NULL_ADDRESS } from "@daostack/arc.js";
+import { IDAOState, IPluginManagerProposalState, NULL_ADDRESS, IGenesisProtocolParams } from "@daostack/arc.js";
 import classNames from "classnames";
-import { copyToClipboard, getNetworkName, linkToEtherScan } from "lib/util";
+import { copyToClipboard, getNetworkName, linkToEtherScan, toBaseUnit } from "lib/util";
 import { pluginNameAndAddress } from "lib/pluginUtils";
 import * as React from "react";
 import { NotificationStatus, showNotification } from "reducers/notifications";
 import { IProfileState } from "reducers/profilesReducer";
 import { connect } from "react-redux";
 import * as css from "./ProposalSummary.scss";
-import * as moment from "moment";
 import { GenericPluginRegistry } from "genericPluginRegistry";
+import { PLUGIN_NAMES } from "lib/pluginUtils";
+import { renderGpParams } from "components/Plugin/PluginInfoPage";
 
 interface IDispatchProps {
   showNotification: typeof showNotification;
@@ -32,6 +33,29 @@ const mapDispatchToProps = {
   showNotification,
 };
 
+/**
+ * Given an array of voting params values from the decoded data, returns IGenesisProtocolParams object
+ * @param {Array<any>} votingParams
+ * @returns {IGenesisProtocolParams}
+ */
+const mapVoteParamsToGenesisParams = (votingParams: Array<any>): IGenesisProtocolParams => {
+  const genesisProtocolParams: IGenesisProtocolParams = {
+    activationTime: votingParams[10],
+    boostedVotePeriodLimit: votingParams[2],
+    daoBountyConst: votingParams[9],
+    limitExponentValue: 0, // This is not included in the decoded data
+    minimumDaoBounty: toBaseUnit(votingParams[8], 18),
+    preBoostedVotePeriodLimit: votingParams[3],
+    proposingRepReward: toBaseUnit(votingParams[6], 18),
+    queuedVoteRequiredPercentage: votingParams[0],
+    queuedVotePeriodLimit: votingParams[1],
+    quietEndingPeriod: votingParams[5],
+    thresholdConst: votingParams[4],
+    votersReputationLossRatio: votingParams[7],
+  };
+  return genesisProtocolParams;
+};
+
 class ProposalSummary extends React.Component<IProps, IState> {
 
   constructor(props: IProps) {
@@ -46,7 +70,7 @@ class ProposalSummary extends React.Component<IProps, IState> {
     this.props.showNotification(NotificationStatus.Success, "Copied to clipboard!");
   };
 
-  public async componentDidMount (): Promise<void> {
+  public async componentDidMount(): Promise<void> {
     this.setState({
       network: (await getNetworkName()).toLowerCase(),
     });
@@ -57,25 +81,30 @@ class ProposalSummary extends React.Component<IProps, IState> {
     let pluginName = proposalState.pluginToRegisterName;
     const decodedData = proposalState.pluginToRegisterDecodedData;
     let votingParams;
+    let genesisProtocolParams: IGenesisProtocolParams;
     let contractToCall;
-    if (pluginName && decodedData && pluginName !== "ReputationFromToken"){ // pluginName && decodedData ---> means the plugin is Add or Replace (not Remove)
+    if (pluginName && decodedData && pluginName !== "ReputationFromToken") { // pluginName && decodedData ---> means the plugin is Add or Replace (not Remove)
       votingParams = decodedData.params[2].value;
-      if (pluginName === "GenericScheme"){
+      if (pluginName === "GenericScheme") {
         contractToCall = decodedData.params[5].value;
         const genericPluginRegistry = new GenericPluginRegistry();
         const genericPluginInfo = genericPluginRegistry.getPluginInfo(decodedData.params[5].value);
-        if (genericPluginInfo){
+        if (genericPluginInfo) {
           pluginName = genericPluginInfo.specs.name;
         } else {
           pluginName = "Blockchain Interaction";
         }
       }
-      else if (pluginName === "ContributionRewardExt"){
+      else if (pluginName === "ContributionRewardExt") {
         pluginName = decodedData.params[7].value; // Rewarder name
       }
-      else if (pluginName === "SchemeFactory"){
-        pluginName = "Plugin Manager";
+      else {
+        pluginName = PLUGIN_NAMES[pluginName as keyof typeof PLUGIN_NAMES];
+        if (pluginName === undefined) {
+          pluginName = "Unknown plugin name";
+        }
       }
+      genesisProtocolParams = mapVoteParamsToGenesisParams(votingParams);
     }
 
     const proposalSummaryClass = classNames({
@@ -93,114 +122,77 @@ class ProposalSummary extends React.Component<IProps, IState> {
         { proposalState.pluginToRemove !== NULL_ADDRESS && !isReplace ?
           <div>
             <span className={css.summaryTitle}>
-              <img src="/assets/images/Icon/delete.svg"/>&nbsp;
+              <img src="/assets/images/Icon/delete.svg" />&nbsp;
                   Remove Plugin&nbsp;
               <a href={linkToEtherScan(proposalState.pluginToRemove)} target="_blank" rel="noopener noreferrer">{pluginNameAndAddress(proposalState.pluginToRemove)}</a>
             </span>
-            { detailView ?
+            {detailView &&
               <div className={css.summaryDetails}>
-                <table><tbody>
-                  <tr>
-                    <th>
-                          Address:
-                      <a href={linkToEtherScan(proposalState.pluginToRemove)} target="_blank" rel="noopener noreferrer">
-                        <img src="/assets/images/Icon/Link-blue.svg"/>
+                <div className={css.detailsRowsContainer}>
+                  <div>Address:</div>
+                  <div>
+                    <a href={linkToEtherScan(proposalState.pluginToRemove)} target="_blank" rel="noopener noreferrer" style={{ marginRight: "5px" }}>
+                      <img src="/assets/images/Icon/Link-blue.svg" />
+                    </a>
+                    {proposalState.pluginToRemove}
+                  </div>
+                </div>
+              </div>}
+          </div>
+          : pluginName &&
+          <div>
+            <span className={css.summaryTitle}>
+              <b className={css.pluginRegisterIcon}>{isReplace ? <img src="/assets/images/Icon/edit-sm.svg" /> : "+"}</b>&nbsp;
+              {isReplace ? "Replace" : "Add"} Plugin&nbsp;
+              {isReplace ? pluginNameAndAddress(proposalState.pluginToRemove) : pluginName}
+            </span>
+            {detailView &&
+              <div className={css.summaryDetails}>
+                <div className={css.detailsRowsContainer}>
+                  {isReplace && <React.Fragment>
+                    <div>Address:</div>
+                    <div>
+                      <a href={linkToEtherScan(proposalState.pluginToRemove)} target="_blank" rel="noopener noreferrer" style={{ marginRight: "5px" }}>
+                        <img src="/assets/images/Icon/Link-blue.svg" />
                       </a>
-                    </th>
-                    <td>{proposalState.pluginToRemove}</td>
-                  </tr>
-                </tbody></table>
+                      {proposalState.pluginToRemove}
+                    </div>
+                  </React.Fragment>}
+                  <div>Name:</div>
+                  <div>{pluginName}</div>
+                  <div>Version:</div>
+                  <div>{proposalState.pluginToRegisterPackageVersion.join(".")}</div>
+                  <div>Init Calldata:</div>
+                  <div>
+                    {proposalState.pluginToRegisterData.substr(0, 10)}...
+                    <img className={css.copyButton} src="/assets/images/Icon/Copy-blue.svg" onClick={this.copyToClipboardHandler(proposalState.pluginToRegisterData)} />
+                  </div>
+                  <div>Permissions:</div>
+                  <div>
+                    {
+                      // eslint-disable-next-line no-bitwise
+                      permissions & 2 ? <div>Register other Plugins</div> : ""
+                    }
+                    {
+                      // eslint-disable-next-line no-bitwise
+                      permissions & 4 ? <div>Change constraints</div> : ""
+                    }
+                    {
+                      // eslint-disable-next-line no-bitwise
+                      permissions & 8 ? <div>Upgrade the controller</div> : ""
+                    }
+                    {
+                      // eslint-disable-next-line no-bitwise
+                      permissions & 16 ? <div>Call genericCall on behalf of</div> : ""
+                    }
+                    <div>Mint or burn reputation</div>
+                  </div>
+                  {renderGpParams(genesisProtocolParams)}
+                  {contractToCall && <React.Fragment><div>Contract to Call:</div><div>{contractToCall}</div></React.Fragment>}
+                </div>
               </div>
-              : ""
             }
           </div>
-          : pluginName ?
-            <div>
-              <span className={css.summaryTitle}>
-                <b className={css.pluginRegisterIcon}>{isReplace ? <img src="/assets/images/Icon/edit-sm.svg"/> : "+"}</b>&nbsp;
-                {isReplace ? "Replace" : "Add"} Plugin&nbsp;
-                {isReplace ? pluginNameAndAddress(proposalState.pluginToRemove) : pluginName}
-                {isReplace ? " With " + pluginName : ""}
-              </span>
-              { detailView ?
-                <div className={css.summaryDetails}>
-                  <table>
-                    <tbody>
-                      {isReplace ?
-                        <tr>
-                          <th>
-                                Address:
-                            <a href={linkToEtherScan(proposalState.pluginToRemove)} target="_blank" rel="noopener noreferrer">
-                              <img src="/assets/images/Icon/Link-blue.svg"/>
-                            </a>
-                          </th>
-                          <td>{proposalState.pluginToRemove}</td>
-                        </tr>
-                        : <></>}
-                      <tr>
-                        <th>Name:</th>
-                        <td>{pluginName}</td>
-                      </tr>
-                      <tr>
-                        <th>Version:</th>
-                        <td>{proposalState.pluginToRegisterPackageVersion.join(".")}</td>
-                      </tr>
-                      <tr>
-                        <th>Init Calldata:</th>
-                        <td>
-                          {proposalState.pluginToRegisterData.substr(0, 10)}...
-                          <img className={css.copyButton} src="/assets/images/Icon/Copy-blue.svg" onClick={this.copyToClipboardHandler(proposalState.pluginToRegisterData)} />
-                        </td>
-                      </tr>
-
-                      { votingParams && (
-                        <React.Fragment>
-                          <tr><th>Queued Vote Required:</th><td>{votingParams[0]}%</td></tr>
-                          <tr><th>Queued Vote Period Limit:</th><td>{votingParams[1]}</td></tr>
-                          <tr><th>Boosted Vote Period Limit:</th><td>{votingParams[2]}</td></tr>
-                          <tr><th>Pre-Boosted Vote Period Limit:</th><td>{votingParams[3]}</td></tr>
-                          <tr><th>Threshold Const:</th><td>{votingParams[4]}</td></tr>
-                          <tr><th>Quiet Ending Period:</th><td>{votingParams[5]}</td></tr>
-                          <tr><th>Proposing Reputation Reward:</th><td>{votingParams[6]}</td></tr>
-                          <tr><th>Voters Reputation Loss Ratio:</th><td>{votingParams[7]}%</td></tr>
-                          <tr><th>Minimum DAO Bounty:</th><td>{votingParams[8]}</td></tr>
-                          <tr><th>DAO Bounty Const:</th><td>{votingParams[9]}</td></tr>
-                          <tr><th>Activation Time:</th><td>{ moment.unix(votingParams[10]).format("YYYY-MM-DD HH:mm")}</td></tr>
-                          {contractToCall && <tr><th>Contract to Call:</th><td>{contractToCall}</td></tr>}
-                        </React.Fragment>)
-                      }
-                      <tr>
-                        <th>Permissions:</th>
-                        <td>
-                          {
-                            // eslint-disable-next-line no-bitwise
-                            permissions & 2 ? <div>Register other Plugins</div> : ""
-                          }
-                          {
-                            // eslint-disable-next-line no-bitwise
-                            permissions & 4 ? <div>Change constraints</div> : ""
-                          }
-                          {
-                            // eslint-disable-next-line no-bitwise
-                            permissions & 8 ? <div>Upgrade the controller</div> : ""
-                          }
-                          {
-                            // eslint-disable-next-line no-bitwise
-                            permissions & 16 ? <div>Call genericCall on behalf of</div> : ""
-                          }
-                          {
-                            <div>Mint or burn reputation</div>
-                          }
-                        </td>
-                      </tr>
-                    </tbody>
-                  </table>
-                </div>
-                : ""
-              }
-            </div>
-            :
-            ""
         }
       </div>
     );

--- a/src/components/Proposal/ProposalSummary/ProposalSummaryPluginManager.tsx
+++ b/src/components/Proposal/ProposalSummary/ProposalSummaryPluginManager.tsx
@@ -58,7 +58,7 @@ class ProposalSummary extends React.Component<IProps, IState> {
     const decodedData = proposalState.pluginToRegisterDecodedData;
     let votingParams;
     let contractToCall;
-    if (proposalState.pluginToRemove === NULL_ADDRESS && pluginName !== "ReputationFromToken"){
+    if ( pluginName && decodedData && pluginName !== "ReputationFromToken"){ // proposalState.pluginToRemove === NULL_ADDRESS // If Plugin to Add or Plugin to Replace
       votingParams = decodedData.params[2].value;
       if (pluginName === "GenericScheme"){
         contractToCall = decodedData.params[5].value;


### PR DESCRIPTION
resolves: https://github.com/daostack/alchemy/issues/2165
resolves: https://github.com/daostack/alchemy/issues/2166

- `renderGpParams` function is now exported from `PluginInfoPage.tsx`
- Plugin Manager Proposal Summary Page is now using grids instead of table and uses `renderGpParams` to render it's GP params.
- Replace Plugin title: the plugin title to be replaced is removed
- Fetching the plugin name from the known `PLUGIN_NAMES` object