### PR TITLE
Fix competition tab crash ; Fix compitition plugin ugly name

### DIFF
--- a/src/components/Plugin/ContributionRewardExtRewarders/Competition/List.tsx
+++ b/src/components/Plugin/ContributionRewardExtRewarders/Competition/List.tsx
@@ -9,7 +9,6 @@ import { getArc } from "arc";
 import { CompetitionStatusEnum, CompetitionStatus } from "./utils";
 import Card from "./Card";
 import * as css from "./Competitions.scss";
-import { GRAPH_POLL_INTERVAL } from "../../../../settings";
 
 interface IExternalProps {
   daoState: IDAOState;
@@ -138,7 +137,7 @@ export default withSubscription({
     `;
 
     const arc = await getArc();
-    await arc.sendQuery(cacheQuery, { polling: true, pollInterval: GRAPH_POLL_INTERVAL });
+    await arc.sendQuery(cacheQuery);
     // end cache priming
 
     // TODO: next lines can use some cleanup up

--- a/src/lib/pluginUtils.ts
+++ b/src/lib/pluginUtils.ts
@@ -105,7 +105,7 @@ export function pluginName(plugin: IPluginState|IContractInfo, fallback?: string
       name = "Blockchain Interaction";
     }
   } else if (plugin.name === "ContributionRewardExt") {
-    name = rewarderContractName(plugin as IContributionRewardExtState);
+    name = rewarderContractName(plugin as IContributionRewardExtState, false);
     if (!name) {
       name = plugin.name;
     } // else name is the rewarder contract alias, or its name split by camel case


### PR DESCRIPTION
resolves: https://github.com/daostack/alchemy/issues/2168

This happens because only Apollo `watchQuery` function accepts `pollInterval` parameter and here we call Apollo `query` function (in arc.js) with `pollInterval` - and that’s why it’s crashes.

**Note:** Maybe we need to limit the option of sending `apolloQueryOptions` / `polling` to a `sendQuery` function in arc.js