### PR TITLE
dao balance not from subgraph

### DIFF
--- a/src/layouts/SidebarMenu.tsx
+++ b/src/layouts/SidebarMenu.tsx
@@ -284,8 +284,8 @@ interface IEthProps extends ISubscriptionProps<BN | null> {
 }
 
 const ETHBalance = (props: IEthProps) => {
-  const { dao } = props;
-  return <li key="ETH"><strong>{formatTokens(new BN(dao.ethBalance))}</strong> {baseTokenName()}</li>;
+  const { data } = props;
+  return <li key="ETH"><strong>{formatTokens(data)}</strong> {baseTokenName()}</li>;
 };
 
 const SubscribedEthBalance = withSubscription({
@@ -295,8 +295,9 @@ const SubscribedEthBalance = withSubscription({
   checkForUpdate: (oldProps: IEthProps, newProps: IEthProps) => {
     return oldProps.dao.address !== newProps.dao.address;
   },
-  createObservable: async () => {
-    return of(null);
+  createObservable: async (props: IEthProps) => {
+    const arc = getArc();
+    return (await arc.dao(props.dao.address).ethBalance()).pipe(ethErrorHandler());
   },
 });
 


### PR DESCRIPTION
Needed because there are some edge cases where the subgraph cannot represent the real balance of a dao.
e.g transferring funds via xdai bridge directly to the dao ..(this will. not trigger a dao event. 