### PR TITLE
Ignore network and GraphQL errors

### DIFF
--- a/src/arc.ts
+++ b/src/arc.ts
@@ -152,7 +152,7 @@ export async function initializeArc(provider?: any): Promise<boolean> {
       },
     });
 
-    arcSettings.retryLink = retryLink;
+    arcSettings.graphqlRetryLink = retryLink;
 
     // if there is no existing arc, we create a new one
     if ((window as any).arc) {

--- a/src/arc.ts
+++ b/src/arc.ts
@@ -1,7 +1,6 @@
 import { NotificationStatus } from "reducers/notifications";
 import { getNetworkId, getNetworkName, targetedNetwork } from "./lib/util";
 import { settings, USE_CONTRACTINFOS_CACHE } from "./settings";
-import { RetryLink } from "apollo-link-retry";
 import { Address, Arc } from "@daostack/arc.js";
 import Web3Modal, { getProviderInfo, IProviderInfo } from "web3modal";
 import { Observable } from "rxjs";
@@ -131,28 +130,6 @@ export async function initializeArc(provider?: any): Promise<boolean> {
     }
 
     const readonly = typeof provider === "string";
-
-    // https://www.apollographql.com/docs/link/links/retry/
-    const retryLink = new RetryLink({
-      attempts: {
-        max: 5,
-        retryIf: (error, _operation) => {
-        // eslint-disable-next-line no-console
-          console.error("error occurred fetching data, retrying...");
-          // eslint-disable-next-line no-console
-          console.log(error);
-          return !!error;
-        },
-      },
-      delay: {
-        initial: 500, // this is the initial time after the first retry
-        // next retries )up to max) will be exponential (i..e after 2*iniitial, etc)
-        jitter: true,
-        max: Infinity,
-      },
-    });
-
-    arcSettings.graphqlRetryLink = retryLink;
 
     // if there is no existing arc, we create a new one
     if ((window as any).arc) {

--- a/src/arc.ts
+++ b/src/arc.ts
@@ -134,16 +134,25 @@ export async function initializeArc(provider?: any): Promise<boolean> {
 
     // https://www.apollographql.com/docs/link/links/retry/
     const retryLink = new RetryLink({
-      attempts: (count) => {
-        return (count !== 10);
+      attempts: {
+        max: 5,
+        retryIf: (error, _operation) => {
+        // eslint-disable-next-line no-console
+          console.error("error occurred fetching data, retrying...");
+          // eslint-disable-next-line no-console
+          console.log(error);
+          return !!error;
+        },
       },
-      delay: () => {
-        // This will give a random delay between retries between the range of 5 to 30 seconds.
-        return Math.floor(Math.random() * (30000 - 5000 + 1) + 5000);
+      delay: {
+        initial: 500, // this is the initial time after the first retry
+        // next retries )up to max) will be exponential (i..e after 2*iniitial, etc)
+        jitter: true,
+        max: Infinity,
       },
     });
 
-    arcSettings.graphqlRetryLink = retryLink;
+    arcSettings.retryLink = retryLink;
 
     // if there is no existing arc, we create a new one
     if ((window as any).arc) {

--- a/src/components/Shared/withSubscription.tsx
+++ b/src/components/Shared/withSubscription.tsx
@@ -108,6 +108,7 @@ const withSubscription = <Props extends ISubscriptionProps<ObservableType>, Obse
 
       this.subscription = this.observable.subscribe(
         (next: ObservableType) => {
+          currentAttempt = 0; // reset on success
           this.setState({
             data: next,
             isLoading: false,


### PR DESCRIPTION
Due to the way Apollo Client works, when a GraphQL or a network error occurs it fails and terminates the observable including the polling, then Alchemy crashes. This is the simplest and cleanest solution to address this issue without changing anything in arc.js.
This is a known bug in Apollo Client `watchQuery` when polling, and looks like the only way to avoid this is to recreate the polling when such an error occurs.