### PR TITLE
Vertical scrolling is added to the sidebar

### DIFF
--- a/src/layouts/SidebarMenu.scss
+++ b/src/layouts/SidebarMenu.scss
@@ -13,6 +13,7 @@
   display: flex;
   flex-direction: column;
   background-color: $sky;
+  overflow-y: scroll;
 
   .daoNameWrapper {
     display: flex;


### PR DESCRIPTION
resolves: https://github.com/daostack/alchemy-monorepo/issues/12

A vertical scrolling is now enabled to the sidebar for small screens when the content overflows.
Regardless of that, I assume Ezra planes to remove some content from the sidebar so it will be more light and thin, thus there will be no scrolling even for small screens.